### PR TITLE
Add AudioChatLLaMA training notebooks and script

### DIFF
--- a/colab_audiochatllama_student.py
+++ b/colab_audiochatllama_student.py
@@ -68,7 +68,7 @@ class CFG:
     assistant_prefix: str = "Answer:"
     sample_rate: int = 16000
     max_duration_s: float = 12.0
-    n_audio_tokens: int = 12
+    audio_subsample: int = 2
     projector_hidden: int = 1024
     train_max_sft_samples: int = 2000
     val_max_sft_samples: int = 200
@@ -172,33 +172,119 @@ def load_frozen_whisper_encoder(cfg: CFG):
 whisper_encoder, whisper_feature_extractor = load_frozen_whisper_encoder(cfg)
 print("Whisper encoder loaded.")
 
-#=== Cell 4: Define AudioProjector (TODO forward)
+#=== Cell 4: Define AudioSubsamplingProjector (TODO forward)
 
 
-class AudioProjector(nn.Module):
-    def __init__(self, input_dim: int, output_dim: int, n_tokens: int = 12, hidden_dim: Optional[int] = None):
+class AudioSubsamplingProjector(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        subsample_factor: int = 2,
+        hidden_dim: Optional[int] = None,
+    ):
         super().__init__()
         hidden_dim = hidden_dim or max(input_dim, output_dim)
-        self.n_tokens = n_tokens
-        self.output_dim = output_dim
-        self.net = nn.Sequential(
-            nn.Linear(input_dim, hidden_dim),
-            nn.GELU(),
-            nn.Linear(hidden_dim, n_tokens * output_dim),
-        )
+        self.subsample_factor = subsample_factor
+        self.proj_in = nn.Linear(input_dim, hidden_dim)
+        self.act = nn.GELU()
+        self.proj_out = nn.Linear(hidden_dim, output_dim)
 
     def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
-        """Project pooled Whisper encoder states into pseudo tokens."""
-        # TODO: average-pool encoder_hidden_states over time and map through self.net
-        # TODO: reshape to (batch, self.n_tokens, self.output_dim)
-        raise NotImplementedError("TODO: implement AudioProjector.forward")
+        """TODO: subsample encoder_hidden_states along time before projecting."""
+        raise NotImplementedError("TODO: implement AudioSubsamplingProjector.forward")
 
 
-audio_projector = AudioProjector(
+audio_projector = AudioSubsamplingProjector(
     input_dim=whisper_encoder.config.d_model,
     output_dim=model.config.hidden_size,
-    n_tokens=cfg.n_audio_tokens,
+    subsample_factor=cfg.audio_subsample,
     hidden_dim=cfg.projector_hidden,
+)
+
+class AudioLLMModel(nn.Module):
+    def __init__(
+        self,
+        llm: AutoModelForCausalLM,
+        whisper_encoder: WhisperModel,
+        audio_projector: nn.Module,
+        tokenizer,
+        audio_token: str,
+    ):
+        super().__init__()
+        self.llm = llm
+        self.whisper_encoder = whisper_encoder
+        self.audio_projector = audio_projector
+        self.tokenizer = tokenizer
+        self.audio_token_id = tokenizer.convert_tokens_to_ids(audio_token)
+
+    def unwrap(self, module: nn.Module) -> nn.Module:
+        return getattr(module, "module", module)
+
+    def _input_embedding_layer(self):
+        return self.unwrap(self.llm).get_input_embeddings()
+
+    def encode_audio(self, input_features: torch.Tensor) -> torch.Tensor:
+        device = next(self.llm.parameters()).device
+        input_features = input_features.to(device)
+        with torch.no_grad():
+            outputs = self.whisper_encoder(input_features)
+        return outputs.last_hidden_state
+
+    def project_audio(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        projected = self.audio_projector(encoder_hidden_states)
+        embed_dtype = self._input_embedding_layer().weight.dtype
+        return projected.to(embed_dtype)
+
+    def trainable_parameters(self):
+        for module in (self.llm, self.audio_projector):
+            for param in module.parameters():
+                if param.requires_grad:
+                    yield param
+
+    def _merge_sequences(
+        self,
+        input_ids: torch.Tensor,
+        token_embeds: torch.Tensor,
+        audio_embeddings: torch.Tensor,
+        labels: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        """TODO: replace SPECIAL_AUDIO tokens with projected audio embeddings."""
+        raise NotImplementedError("TODO: implement AudioLLMModel._merge_sequences")
+
+    def prepare_inputs_and_labels(
+        self,
+        batch: Dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """TODO: encode audio, embed text, and build training inputs/labels."""
+        raise NotImplementedError("TODO: implement AudioLLMModel.prepare_inputs_and_labels")
+
+    def prepare_generation_inputs(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """TODO: build inputs_embeds + attention_mask for generation."""
+        raise NotImplementedError("TODO: implement AudioLLMModel.prepare_generation_inputs")
+
+    def generate(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        """TODO: call self.unwrap(self.llm).generate with merged audio/text inputs."""
+        raise NotImplementedError("TODO: implement AudioLLMModel.generate")
+
+
+audio_llm = AudioLLMModel(
+    llm=model,
+    whisper_encoder=whisper_encoder,
+    audio_projector=audio_projector,
+    tokenizer=tokenizer,
+    audio_token=SPECIAL_AUDIO_TOKEN,
 )
 
 #=== Cell 5: Dataset loaders with SpokenWOZ + fallbacks
@@ -341,17 +427,12 @@ collator = SFTCollator(tokenizer, cfg)
 
 def make_inputs_embeds_and_labels(
     cfg: CFG,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     batch: Dict[str, torch.Tensor],
     device: torch.device,
 ):
     """Combine audio features with text tokens to build model inputs."""
-    # TODO: encode audio with whisper_encoder (no_grad), project via audio_projector
-    # TODO: replace SPECIAL_AUDIO_TOKEN positions with projected audio tokens
-    # TODO: construct labels using loss_mask (set prompt positions to -100)
+    # TODO: call audio_model.prepare_inputs_and_labels and return its outputs
     raise NotImplementedError("TODO: implement make_inputs_embeds_and_labels")
 
 
@@ -365,7 +446,7 @@ train_loader = DataLoader(
     num_workers=cfg.num_workers,
 )
 optimizer = AdamW(
-    list(model.parameters()) + list(audio_projector.parameters()),
+    list(audio_llm.trainable_parameters()),
     lr=cfg.lr,
     weight_decay=cfg.weight_decay,
 )
@@ -375,15 +456,23 @@ scheduler = get_linear_schedule_with_warmup(
     num_warmup_steps=int(cfg.warmup_ratio * num_training_steps),
     num_training_steps=num_training_steps,
 )
-model, optimizer, train_loader, scheduler = accelerator.prepare(model, optimizer, train_loader, scheduler)
-audio_projector = audio_projector.to(accelerator.device)
-whisper_encoder = whisper_encoder.to(accelerator.device)
+prepared_llm, prepared_projector, optimizer, train_loader, scheduler = accelerator.prepare(
+    audio_llm.llm,
+    audio_llm.audio_projector,
+    optimizer,
+    train_loader,
+    scheduler,
+)
+audio_llm.llm = prepared_llm
+audio_llm.audio_projector = prepared_projector
+audio_llm.whisper_encoder = audio_llm.whisper_encoder.to(accelerator.device)
+audio_llm.whisper_encoder.eval()
 
 
 def train_epoch(epoch: int):
     """Single epoch training with gradient accumulation and AMP."""
-    # TODO: iterate over train_loader, build embeds via make_inputs_embeds_and_labels,
-    #       compute loss, backprop, optimizer/scheduler steps, and log every cfg.logging_steps
+    # TODO: iterate over train_loader, use make_inputs_embeds_and_labels(cfg, audio_llm, ...),
+    #       compute loss with audio_llm.llm, backprop, optimizer/scheduler steps, and log every cfg.logging_steps
     raise NotImplementedError("TODO: implement train_epoch")
 
 
@@ -396,19 +485,35 @@ for epoch in range(cfg.epochs):
 
 #=== Cell 10: MMLU-Speech evaluation (TODO)
 
+def generate_from_audio_batch(
+    cfg: CFG,
+    audio_model: AudioLLMModel,
+    audio_features: torch.Tensor,
+    max_new_tokens: int = 64,
+    temperature: float = 0.0,
+):
+    prompts = []
+    for _ in range(audio_features.size(0)):
+        system = cfg.system_prompt
+        user = cfg.user_prompt_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+        prompts.append(f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:")
+
+    generation_kwargs = {
+        "max_new_tokens": max_new_tokens,
+        "temperature": temperature,
+        "do_sample": temperature > 0,
+    }
+    return audio_model.generate(prompts, audio_features, generation_kwargs)
+
 def evaluate_mmlu_speech(
     cfg: CFG,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     feature_extractor,
     max_samples: Optional[int] = None,
 ):
     """Evaluate zero-shot multiple-choice accuracy on mistralai/mmlu_speech."""
     # TODO: iterate over evaluation DataLoader, build prompts with SPECIAL_AUDIO_TOKEN,
-    #       generate answers, parse via regex, compute overall + per-subject accuracy,
-    #       print qualitative examples (10 items).
+    #       call audio_model.generate, parse answers, compute metrics, log qualitative samples.
     raise NotImplementedError("TODO: implement evaluate_mmlu_speech")
 
 

--- a/colab_audiochatllama_student.py
+++ b/colab_audiochatllama_student.py
@@ -1,0 +1,417 @@
+-----BEGIN COLAB STUDENT NOTEBOOK-----
+#=== Cell 0: Setup & Installs
+"""Student Colab notebook for the AudioChatLLaMA-style pipeline."""
+import sys
+import subprocess
+import pkgutil
+
+REQUIRED_PACKAGES = {
+    "transformers": "4.44.2",
+    "datasets": "2.20.0",
+    "accelerate": "0.33.0",
+    "peft": "0.11.1",
+    "torchaudio": "2.3.1",
+    "soundfile": "0.12.1",
+    "jiwer": "3.0.3",
+    "einops": "0.7.0",
+}
+
+for pkg, ver in REQUIRED_PACKAGES.items():
+    if pkgutil.find_loader(pkg) is None:
+        print(f"Installing {pkg}=={ver}")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{pkg}=={ver}"])
+
+try:
+    import bitsandbytes  # noqa: F401
+except ImportError:
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "bitsandbytes==0.43.1"])
+    except Exception:
+        print("bitsandbytes unavailable; continue without 4-bit mode.")
+
+import json
+import math
+import os
+import random
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+import torchaudio
+import soundfile as sf
+
+from accelerate import Accelerator
+from datasets import Dataset, load_dataset
+from peft import LoraConfig, TaskType, get_peft_model
+from transformers import (
+    AdamW,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    WhisperFeatureExtractor,
+    WhisperModel,
+    get_linear_schedule_with_warmup,
+)
+
+#=== Cell 1: Config (CFG) with toggles/paths
+@dataclass
+class CFG:
+    cache_dir: Optional[str] = None
+    output_dir: str = "./audiollama_outputs_student"
+    system_prompt: str = "You are an assistant for spoken multiple-choice exams."
+    user_prompt_template: str = "<AUDIO> Select the best answer to the spoken question."
+    assistant_prefix: str = "Answer:"
+    sample_rate: int = 16000
+    max_duration_s: float = 12.0
+    n_audio_tokens: int = 12
+    projector_hidden: int = 1024
+    train_max_sft_samples: int = 2000
+    val_max_sft_samples: int = 200
+    mmlu_speech_max: int = 1500
+    lr: float = 1e-4
+    weight_decay: float = 0.01
+    epochs: int = 1
+    batch_size: int = 4
+    grad_accum_steps: int = 4
+    amp: bool = True
+    use_4bit: bool = False
+    seed: int = 42
+    warmup_ratio: float = 0.03
+    logging_steps: int = 10
+    save_every: int = 200
+    eval_every: int = 200
+    train_use_slurp: bool = False
+    train_use_dailytalk: bool = False
+    train_use_commonvoice: bool = False
+    num_workers: int = 2
+    gradient_checkpointing: bool = True
+
+cfg = CFG()
+os.makedirs(cfg.output_dir, exist_ok=True)
+random.seed(cfg.seed)
+np.random.seed(cfg.seed)
+torch.manual_seed(cfg.seed)
+
+SPECIAL_AUDIO_TOKEN = "<|AUDIO|>"
+
+#=== Cell 2: Load tokenizer + LLM (Qwen3-0.6B-Base) and add LoRA
+
+def load_llm_and_tokenizer(cfg: CFG):
+    tokenizer = AutoTokenizer.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        use_fast=False,
+    )
+    if SPECIAL_AUDIO_TOKEN not in tokenizer.get_vocab():
+        tokenizer.add_special_tokens({"additional_special_tokens": [SPECIAL_AUDIO_TOKEN]})
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    compute_dtype = torch.float16
+    if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+        compute_dtype = torch.bfloat16
+
+    quant_config = None
+    if cfg.use_4bit:
+        quant_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=compute_dtype,
+            bnb_4bit_use_double_quant=True,
+        )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        torch_dtype=compute_dtype,
+        quantization_config=quant_config,
+        device_map="auto" if cfg.use_4bit else None,
+    )
+    model.resize_token_embeddings(len(tokenizer))
+
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+        lora_dropout=0.05,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
+    )
+    model = get_peft_model(model, lora_config)
+    if cfg.gradient_checkpointing:
+        model.gradient_checkpointing_enable()
+        model.enable_input_require_grads()
+    model.config.use_cache = False
+    return model, tokenizer
+
+
+model, tokenizer = load_llm_and_tokenizer(cfg)
+print("LLM with LoRA ready.")
+
+#=== Cell 3: Load Whisper-medium encoder & feature_extractor (frozen)
+
+def load_frozen_whisper_encoder(cfg: CFG):
+    feature_extractor = WhisperFeatureExtractor.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper = WhisperModel.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper.encoder.requires_grad_(False)
+    whisper.encoder.eval()
+    return whisper.encoder, feature_extractor
+
+
+whisper_encoder, whisper_feature_extractor = load_frozen_whisper_encoder(cfg)
+print("Whisper encoder loaded.")
+
+#=== Cell 4: Define AudioProjector (TODO forward)
+
+
+class AudioProjector(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, n_tokens: int = 12, hidden_dim: Optional[int] = None):
+        super().__init__()
+        hidden_dim = hidden_dim or max(input_dim, output_dim)
+        self.n_tokens = n_tokens
+        self.output_dim = output_dim
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, n_tokens * output_dim),
+        )
+
+    def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project pooled Whisper encoder states into pseudo tokens."""
+        # TODO: average-pool encoder_hidden_states over time and map through self.net
+        # TODO: reshape to (batch, self.n_tokens, self.output_dim)
+        raise NotImplementedError("TODO: implement AudioProjector.forward")
+
+
+audio_projector = AudioProjector(
+    input_dim=whisper_encoder.config.d_model,
+    output_dim=model.config.hidden_size,
+    n_tokens=cfg.n_audio_tokens,
+    hidden_dim=cfg.projector_hidden,
+)
+
+#=== Cell 5: Dataset loaders with SpokenWOZ + fallbacks
+
+def _resample_audio(audio: Dict[str, Any], target_sr: int) -> np.ndarray:
+    array = audio["array"] if isinstance(audio, dict) else audio
+    sr = audio.get("sampling_rate", target_sr) if isinstance(audio, dict) else target_sr
+    if sr != target_sr:
+        tensor = torch.tensor(array).float()
+        array = torchaudio.functional.resample(tensor, sr, target_sr).numpy()
+    return np.asarray(array, dtype=np.float32)
+
+
+def _compute_features(batch: Dict[str, Any], feature_extractor, cfg: CFG) -> Dict[str, Any]:
+    waveform = _resample_audio(batch["audio"], cfg.sample_rate)
+    duration = waveform.shape[-1] / cfg.sample_rate
+    if duration > cfg.max_duration_s:
+        waveform = waveform[: int(cfg.max_duration_s * cfg.sample_rate)]
+    batch["input_features"] = feature_extractor(
+        waveform,
+        sampling_rate=cfg.sample_rate,
+        return_tensors="pt",
+    )["input_features"][0]
+    return batch
+
+
+def _fallback_dataset(cfg: CFG, feature_extractor, num_samples: int = 200) -> Dataset:
+    rng = np.random.default_rng(cfg.seed)
+    dummy_texts = [
+        "Synthetic knowledge sample.",
+        "Placeholder response for audio.",
+    ]
+    examples = []
+    for _ in range(num_samples):
+        waveform = rng.normal(0, 0.01, size=int(cfg.sample_rate * 2.5)).astype(np.float32)
+        features = feature_extractor(
+            waveform,
+            sampling_rate=cfg.sample_rate,
+            return_tensors="pt",
+        )["input_features"][0]
+        examples.append({
+            "input_features": features,
+            "text": random.choice(dummy_texts),
+            "audio": {"array": waveform, "sampling_rate": cfg.sample_rate},
+        })
+    return Dataset.from_list(examples)
+
+
+def load_spokenwoz(cfg: CFG, feature_extractor) -> Dataset:
+    try_names = ["facebook/SpokenWOZ", "LIUM/SpokenWOZ"]
+    dataset = None
+    for name in try_names:
+        try:
+            dataset = load_dataset(name, split="train", cache_dir=cfg.cache_dir)
+            break
+        except Exception:
+            continue
+    if dataset is None:
+        print("Falling back to synthetic SpokenWOZ subset.")
+        return _fallback_dataset(cfg, feature_extractor)
+
+    def mapper(example):
+        audio = None
+        for key in ["audio", "speech", "target_speech", "spoken_audio"]:
+            if key in example and example[key] is not None:
+                audio = example[key]
+                break
+        if audio is None:
+            return None
+        text = example.get("text") or example.get("response") or example.get("answer") or ""
+        if isinstance(text, list):
+            text = " ".join([t for t in text if t])
+        return {"audio": audio, "text": text}
+
+    dataset = dataset.map(mapper, remove_columns=dataset.column_names)
+    dataset = dataset.filter(lambda x: x is not None and x["text"])
+    dataset = dataset.map(lambda x: _compute_features(x, feature_extractor, cfg))
+    return dataset
+
+
+def load_datasets(cfg: CFG, feature_extractor) -> Tuple[Dataset, Dataset]:
+    train_dataset = load_spokenwoz(cfg, feature_extractor)
+    if cfg.train_max_sft_samples:
+        train_dataset = train_dataset.select(range(min(len(train_dataset), cfg.train_max_sft_samples)))
+    val_dataset = train_dataset.take(min(len(train_dataset), cfg.val_max_sft_samples))
+    return train_dataset, val_dataset
+
+
+train_dataset, val_dataset = load_datasets(cfg, whisper_feature_extractor)
+print(train_dataset)
+
+#=== Cell 6: Collator & preprocessing
+
+
+class SFTCollator:
+    def __init__(self, tokenizer, cfg: CFG):
+        self.tokenizer = tokenizer
+        self.cfg = cfg
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        audio_features = [torch.tensor(f["input_features"], dtype=torch.float32) for f in features]
+        texts = [f["text"] for f in features]
+        prompt_pairs = []
+        for text in texts:
+            system = cfg.system_prompt
+            user = cfg.user_prompt_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+            assistant = f"{cfg.assistant_prefix} {text}".strip()
+            prompt_pairs.append((f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:", assistant))
+
+        input_ids = []
+        loss_masks = []
+        for prompt, answer in prompt_pairs:
+            prompt_ids = tokenizer(prompt, add_special_tokens=False).input_ids
+            answer_ids = tokenizer(answer + tokenizer.eos_token, add_special_tokens=False).input_ids
+            ids = prompt_ids + answer_ids
+            mask = [0] * len(prompt_ids) + [1] * len(answer_ids)
+            input_ids.append(torch.tensor(ids, dtype=torch.long))
+            loss_masks.append(torch.tensor(mask, dtype=torch.long))
+
+        max_len = max(t.size(0) for t in input_ids)
+        padded_ids, padded_masks = [], []
+        for ids, mask in zip(input_ids, loss_masks):
+            pad_len = max_len - ids.size(0)
+            if pad_len > 0:
+                ids = torch.cat([ids, torch.full((pad_len,), tokenizer.pad_token_id, dtype=torch.long)])
+                mask = torch.cat([mask, torch.zeros(pad_len, dtype=torch.long)])
+            padded_ids.append(ids)
+            padded_masks.append(mask)
+
+        return {
+            "input_features": torch.stack(audio_features),
+            "input_ids": torch.stack(padded_ids),
+            "loss_mask": torch.stack(padded_masks),
+        }
+
+
+collator = SFTCollator(tokenizer, cfg)
+
+#=== Cell 7: Prompt embeddings builder (TODO make_inputs_embeds_and_labels)
+
+def make_inputs_embeds_and_labels(
+    cfg: CFG,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    batch: Dict[str, torch.Tensor],
+    device: torch.device,
+):
+    """Combine audio features with text tokens to build model inputs."""
+    # TODO: encode audio with whisper_encoder (no_grad), project via audio_projector
+    # TODO: replace SPECIAL_AUDIO_TOKEN positions with projected audio tokens
+    # TODO: construct labels using loss_mask (set prompt positions to -100)
+    raise NotImplementedError("TODO: implement make_inputs_embeds_and_labels")
+
+
+#=== Cell 8: Training loop (TODO)
+accelerator = Accelerator()
+train_loader = DataLoader(
+    train_dataset,
+    batch_size=cfg.batch_size,
+    shuffle=True,
+    collate_fn=collator,
+    num_workers=cfg.num_workers,
+)
+optimizer = AdamW(
+    list(model.parameters()) + list(audio_projector.parameters()),
+    lr=cfg.lr,
+    weight_decay=cfg.weight_decay,
+)
+num_training_steps = math.ceil(len(train_loader) / cfg.grad_accum_steps) * cfg.epochs
+scheduler = get_linear_schedule_with_warmup(
+    optimizer,
+    num_warmup_steps=int(cfg.warmup_ratio * num_training_steps),
+    num_training_steps=num_training_steps,
+)
+model, optimizer, train_loader, scheduler = accelerator.prepare(model, optimizer, train_loader, scheduler)
+audio_projector = audio_projector.to(accelerator.device)
+whisper_encoder = whisper_encoder.to(accelerator.device)
+
+
+def train_epoch(epoch: int):
+    """Single epoch training with gradient accumulation and AMP."""
+    # TODO: iterate over train_loader, build embeds via make_inputs_embeds_and_labels,
+    #       compute loss, backprop, optimizer/scheduler steps, and log every cfg.logging_steps
+    raise NotImplementedError("TODO: implement train_epoch")
+
+
+for epoch in range(cfg.epochs):
+    # TODO: call train_epoch(epoch) and report averaged loss
+    pass
+
+#=== Cell 9: Save adapters (TODO)
+# TODO: unwrap accelerator model, save adapters to cfg.output_dir/adapters, save audio_projector state_dict
+
+#=== Cell 10: MMLU-Speech evaluation (TODO)
+
+def evaluate_mmlu_speech(
+    cfg: CFG,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    feature_extractor,
+    max_samples: Optional[int] = None,
+):
+    """Evaluate zero-shot multiple-choice accuracy on mistralai/mmlu_speech."""
+    # TODO: iterate over evaluation DataLoader, build prompts with SPECIAL_AUDIO_TOKEN,
+    #       generate answers, parse via regex, compute overall + per-subject accuracy,
+    #       print qualitative examples (10 items).
+    raise NotImplementedError("TODO: implement evaluate_mmlu_speech")
+
+
+#=== Cell 11: Inference helper (TODO)
+# TODO: implement transcribe_and_answer that loads a WAV, extracts features, calls generate_from_audio_batch
+-----END COLAB STUDENT NOTEBOOK-----

--- a/colab_audiochatllama_teacher.py
+++ b/colab_audiochatllama_teacher.py
@@ -1,0 +1,707 @@
+-----BEGIN COLAB TEACHER NOTEBOOK-----
+#=== Cell 0: Setup & Installs
+"""Teacher Colab notebook for lightweight AudioChatLLaMA-style pipeline."""
+import sys
+import subprocess
+import pkgutil
+
+REQUIRED_PACKAGES = {
+    "transformers": "4.44.2",
+    "datasets": "2.20.0",
+    "accelerate": "0.33.0",
+    "peft": "0.11.1",
+    "torchaudio": "2.3.1",
+    "soundfile": "0.12.1",
+    "jiwer": "3.0.3",
+    "einops": "0.7.0",
+}
+
+for pkg, ver in REQUIRED_PACKAGES.items():
+    if pkgutil.find_loader(pkg) is None:
+        print(f"Installing {pkg}=={ver}")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", f"{pkg}=={ver}"])
+
+try:
+    import bitsandbytes  # noqa: F401
+except ImportError:
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "bitsandbytes==0.43.1"])
+    except Exception as exc:
+        print("bitsandbytes install failed, continuing without it:", exc)
+
+import json
+import math
+import os
+import random
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+import torchaudio
+import soundfile as sf
+
+from accelerate import Accelerator
+from datasets import Dataset, load_dataset
+from peft import LoraConfig, TaskType, get_peft_model
+from transformers import (
+    AdamW,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    GenerationConfig,
+    WhisperFeatureExtractor,
+    WhisperModel,
+    get_linear_schedule_with_warmup,
+)
+
+#=== Cell 1: Config (CFG) with toggles/paths
+@dataclass
+class CFG:
+    cache_dir: Optional[str] = None
+    output_dir: str = "./audiollama_outputs"
+    system_prompt: str = "You are an assistant for spoken multiple-choice exams."
+    user_prompt_template: str = "<AUDIO> Select the best answer to the spoken question."
+    assistant_prefix: str = "Answer:"
+    sample_rate: int = 16000
+    max_duration_s: float = 12.0
+    n_audio_tokens: int = 12
+    projector_hidden: int = 1024
+    train_max_sft_samples: int = 2000
+    val_max_sft_samples: int = 200
+    mmlu_speech_max: int = 1500
+    lr: float = 1e-4
+    weight_decay: float = 0.01
+    epochs: int = 1
+    batch_size: int = 4
+    grad_accum_steps: int = 4
+    amp: bool = True
+    use_4bit: bool = False
+    seed: int = 42
+    warmup_ratio: float = 0.03
+    logging_steps: int = 10
+    save_every: int = 200
+    eval_every: int = 200
+    train_use_slurp: bool = False
+    train_use_dailytalk: bool = False
+    train_use_commonvoice: bool = False
+    num_workers: int = 2
+    gradient_checkpointing: bool = True
+
+cfg = CFG()
+os.makedirs(cfg.output_dir, exist_ok=True)
+random.seed(cfg.seed)
+np.random.seed(cfg.seed)
+torch.manual_seed(cfg.seed)
+
+SPECIAL_AUDIO_TOKEN = "<|AUDIO|>"
+
+#=== Cell 2: Load tokenizer + LLM (Qwen3-0.6B-Base) and add LoRA
+
+def load_llm_and_tokenizer(cfg: CFG):
+    tokenizer = AutoTokenizer.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        use_fast=False,
+    )
+    if SPECIAL_AUDIO_TOKEN not in tokenizer.get_vocab():
+        tokenizer.add_special_tokens({"additional_special_tokens": [SPECIAL_AUDIO_TOKEN]})
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    compute_dtype = torch.float16
+    if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+        compute_dtype = torch.bfloat16
+
+    quant_config = None
+    if cfg.use_4bit:
+        quant_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=compute_dtype,
+            bnb_4bit_use_double_quant=True,
+        )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        torch_dtype=compute_dtype,
+        quantization_config=quant_config,
+        device_map="auto" if cfg.use_4bit else None,
+    )
+    model.resize_token_embeddings(len(tokenizer))
+
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+        lora_dropout=0.05,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
+    )
+    model = get_peft_model(model, lora_config)
+    if cfg.gradient_checkpointing:
+        model.gradient_checkpointing_enable()
+        model.enable_input_require_grads()
+    model.config.use_cache = False
+    return model, tokenizer, compute_dtype
+
+
+model, tokenizer, compute_dtype = load_llm_and_tokenizer(cfg)
+print("Loaded Qwen3 0.6B with LoRA adapters.")
+
+#=== Cell 3: Load Whisper-medium encoder & feature_extractor (frozen)
+
+def load_frozen_whisper_encoder(cfg: CFG):
+    feature_extractor = WhisperFeatureExtractor.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper = WhisperModel.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper.encoder.requires_grad_(False)
+    whisper.encoder.eval()
+    return whisper.encoder, feature_extractor
+
+
+whisper_encoder, whisper_feature_extractor = load_frozen_whisper_encoder(cfg)
+print("Whisper encoder hidden size:", whisper_encoder.config.d_model)
+
+#=== Cell 4: Define AudioProjector (in_dim = whisper d_model, out_dim = LLM hidden, N tokens)
+
+
+class AudioProjector(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, n_tokens: int = 12, hidden_dim: Optional[int] = None):
+        super().__init__()
+        hidden_dim = hidden_dim or max(input_dim, output_dim)
+        self.n_tokens = n_tokens
+        self.output_dim = output_dim
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, n_tokens * output_dim),
+        )
+
+    def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        pooled = encoder_hidden_states.mean(dim=1)
+        projected = self.net(pooled)
+        projected = projected.view(-1, self.n_tokens, self.output_dim)
+        return projected
+
+
+audio_projector = AudioProjector(
+    input_dim=whisper_encoder.config.d_model,
+    output_dim=model.config.hidden_size,
+    n_tokens=cfg.n_audio_tokens,
+    hidden_dim=cfg.projector_hidden,
+)
+print(audio_projector)
+
+#=== Cell 5: Dataset loaders with SpokenWOZ + optional fallbacks
+
+def _resample_audio(audio: Dict[str, Any], target_sr: int) -> np.ndarray:
+    array = audio["array"] if isinstance(audio, dict) else audio
+    sr = audio.get("sampling_rate", target_sr) if isinstance(audio, dict) else target_sr
+    if sr != target_sr:
+        tensor = torch.tensor(array).float()
+        array = torchaudio.functional.resample(tensor, sr, target_sr).numpy()
+    return np.asarray(array, dtype=np.float32)
+
+
+def _compute_features(batch: Dict[str, Any], feature_extractor, cfg: CFG) -> Dict[str, Any]:
+    waveform = _resample_audio(batch["audio"], cfg.sample_rate)
+    duration = waveform.shape[-1] / cfg.sample_rate
+    if duration > cfg.max_duration_s:
+        waveform = waveform[: int(cfg.max_duration_s * cfg.sample_rate)]
+    batch["input_features"] = feature_extractor(
+        waveform,
+        sampling_rate=cfg.sample_rate,
+        return_tensors="pt",
+    )["input_features"][0]
+    return batch
+
+
+def _fallback_dataset(cfg: CFG, feature_extractor, num_samples: int = 200) -> Dataset:
+    rng = np.random.default_rng(cfg.seed)
+    examples = []
+    dummy_texts = [
+        "The capital of France is Paris.",
+        "Two plus two equals four.",
+        "Water boils at one hundred degrees Celsius.",
+        "Photosynthesis occurs in plant chloroplasts.",
+    ]
+    for _ in range(num_samples):
+        waveform = rng.normal(0, 0.01, size=int(cfg.sample_rate * 2.5)).astype(np.float32)
+        features = feature_extractor(
+            waveform,
+            sampling_rate=cfg.sample_rate,
+            return_tensors="pt",
+        )["input_features"][0]
+        examples.append({
+            "input_features": features,
+            "text": random.choice(dummy_texts),
+            "audio": {"array": waveform, "sampling_rate": cfg.sample_rate},
+        })
+    return Dataset.from_list(examples)
+
+
+def load_spokenwoz(cfg: CFG, feature_extractor) -> Dataset:
+    tried = ["facebook/SpokenWOZ", "LIUM/SpokenWOZ"]
+    dataset = None
+    last_error = None
+    for name in tried:
+        try:
+            dataset = load_dataset(name, split="train", cache_dir=cfg.cache_dir)
+            break
+        except Exception as exc:
+            last_error = exc
+    if dataset is None:
+        print("Falling back to synthetic dataset:", last_error)
+        return _fallback_dataset(cfg, feature_extractor)
+
+    def mapper(example):
+        audio = None
+        for key in ["audio", "speech", "target_speech", "spoken_audio"]:
+            if key in example and example[key] is not None:
+                audio = example[key]
+                break
+        if audio is None:
+            return None
+        text = example.get("text") or example.get("response") or example.get("answer") or ""
+        if isinstance(text, list):
+            text = " ".join([t for t in text if t])
+        return {"audio": audio, "text": text}
+
+    dataset = dataset.map(mapper, remove_columns=dataset.column_names)
+    dataset = dataset.filter(lambda x: x is not None and x["text"])
+    dataset = dataset.map(lambda x: _compute_features(x, feature_extractor, cfg))
+    return dataset
+
+
+def load_datasets(cfg: CFG, feature_extractor) -> Tuple[Dataset, Dataset]:
+    train_dataset = load_spokenwoz(cfg, feature_extractor)
+    if cfg.train_use_slurp:
+        try:
+            slurp = load_dataset("slurp", split="train[:200]", cache_dir=cfg.cache_dir)
+            slurp = slurp.map(lambda x: {"audio": x["audio"], "text": x.get("sentence", "")})
+            slurp = slurp.map(lambda x: _compute_features(x, feature_extractor, cfg))
+            train_dataset = Dataset.from_list(train_dataset.to_list() + slurp.to_list())
+        except Exception as exc:
+            print("Failed to load SLURP:", exc)
+    if cfg.train_max_sft_samples:
+        train_dataset = train_dataset.select(range(min(len(train_dataset), cfg.train_max_sft_samples)))
+    val_dataset = train_dataset.take(min(len(train_dataset), cfg.val_max_sft_samples))
+    return train_dataset, val_dataset
+
+
+train_dataset, val_dataset = load_datasets(cfg, whisper_feature_extractor)
+print(train_dataset)
+
+#=== Cell 6: Collator & preprocessing
+
+
+class SFTCollator:
+    def __init__(self, tokenizer, cfg: CFG):
+        self.tokenizer = tokenizer
+        self.cfg = cfg
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        audio_features = [torch.tensor(f["input_features"], dtype=torch.float32) for f in features]
+        texts = [f["text"] for f in features]
+        prompt_pairs = []
+        for text in texts:
+            system = cfg.system_prompt
+            user = cfg.user_prompt_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+            assistant = f"{cfg.assistant_prefix} {text}".strip()
+            prompt_pairs.append((f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:", assistant))
+
+        input_ids = []
+        loss_masks = []
+        for prompt, answer in prompt_pairs:
+            prompt_ids = tokenizer(prompt, add_special_tokens=False).input_ids
+            answer_ids = tokenizer(answer + tokenizer.eos_token, add_special_tokens=False).input_ids
+            ids = prompt_ids + answer_ids
+            mask = [0] * len(prompt_ids) + [1] * len(answer_ids)
+            input_ids.append(torch.tensor(ids, dtype=torch.long))
+            loss_masks.append(torch.tensor(mask, dtype=torch.long))
+
+        max_len = max(t.size(0) for t in input_ids)
+        padded_ids, padded_masks = [], []
+        for ids, mask in zip(input_ids, loss_masks):
+            pad_len = max_len - ids.size(0)
+            if pad_len > 0:
+                ids = torch.cat([ids, torch.full((pad_len,), tokenizer.pad_token_id, dtype=torch.long)])
+                mask = torch.cat([mask, torch.zeros(pad_len, dtype=torch.long)])
+            padded_ids.append(ids)
+            padded_masks.append(mask)
+
+        return {
+            "input_features": torch.stack(audio_features),
+            "input_ids": torch.stack(padded_ids),
+            "loss_mask": torch.stack(padded_masks),
+        }
+
+
+collator = SFTCollator(tokenizer, cfg)
+
+#=== Cell 7: Prompt embeddings builder (make_inputs_embeds_and_labels)
+
+def make_inputs_embeds_and_labels(
+    cfg: CFG,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    batch: Dict[str, torch.Tensor],
+    device: torch.device,
+):
+    input_features = batch["input_features"].to(device)
+    input_ids = batch["input_ids"].to(device)
+    loss_mask = batch["loss_mask"].to(device)
+
+    with torch.no_grad():
+        whisper_outputs = whisper_encoder(input_features)
+        audio_hidden = whisper_outputs.last_hidden_state
+    audio_tokens = audio_projector(audio_hidden)
+
+    token_embeds = model.get_input_embeddings()(input_ids)
+    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+    expanded_embeds = []
+    expanded_labels = []
+    expanded_masks = []
+    for b in range(input_ids.size(0)):
+        ids = input_ids[b]
+        embeds = token_embeds[b]
+        labels = ids.clone()
+        labels[loss_mask[b] == 0] = -100
+        seq_embeds = []
+        seq_labels = []
+        seq_mask = []
+        for token_id, token_embed, label in zip(ids, embeds, labels):
+            if token_id == audio_token_id:
+                for j in range(audio_projector.n_audio_tokens):
+                    seq_embeds.append(audio_tokens[b, j])
+                    seq_labels.append(torch.tensor(-100, device=device))
+                    seq_mask.append(torch.tensor(1, device=device))
+            else:
+                seq_embeds.append(token_embed)
+                seq_labels.append(label)
+                seq_mask.append(torch.tensor(1, device=device))
+        seq_embeds = torch.stack(seq_embeds)
+        seq_labels = torch.stack(seq_labels)
+        seq_mask = torch.stack(seq_mask)
+        expanded_embeds.append(seq_embeds)
+        expanded_labels.append(seq_labels)
+        expanded_masks.append(seq_mask)
+
+    max_len = max(t.size(0) for t in expanded_embeds)
+    padded_embeds, padded_labels, padded_masks = [], [], []
+    for embeds, labels, mask in zip(expanded_embeds, expanded_labels, expanded_masks):
+        pad_len = max_len - embeds.size(0)
+        if pad_len > 0:
+            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+            labels = torch.cat([labels, torch.full((pad_len,), -100, device=device, dtype=torch.long)], dim=0)
+            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+        padded_embeds.append(embeds)
+        padded_labels.append(labels)
+        padded_masks.append(mask)
+
+    return torch.stack(padded_embeds), torch.stack(padded_masks), torch.stack(padded_labels)
+
+
+#=== Cell 8: Training loop (loss prints every N steps)
+accelerator = Accelerator()
+train_loader = DataLoader(
+    train_dataset,
+    batch_size=cfg.batch_size,
+    shuffle=True,
+    collate_fn=collator,
+    num_workers=cfg.num_workers,
+)
+optimizer = AdamW(
+    list(model.parameters()) + list(audio_projector.parameters()),
+    lr=cfg.lr,
+    weight_decay=cfg.weight_decay,
+)
+num_training_steps = math.ceil(len(train_loader) / cfg.grad_accum_steps) * cfg.epochs
+scheduler = get_linear_schedule_with_warmup(
+    optimizer,
+    num_warmup_steps=int(cfg.warmup_ratio * num_training_steps),
+    num_training_steps=num_training_steps,
+)
+model, optimizer, train_loader, scheduler = accelerator.prepare(model, optimizer, train_loader, scheduler)
+audio_projector = audio_projector.to(accelerator.device)
+whisper_encoder = whisper_encoder.to(accelerator.device)
+
+def train_epoch(epoch: int):
+    model.train()
+    audio_projector.train()
+    total_loss = 0.0
+    scaler = torch.cuda.amp.GradScaler(enabled=cfg.amp and accelerator.device.type == "cuda")
+
+    for step, batch in enumerate(train_loader, start=1):
+        with accelerator.accumulate(model):
+            inputs_embeds, attention_mask, labels = make_inputs_embeds_and_labels(
+                cfg,
+                model,
+                tokenizer,
+                audio_projector,
+                whisper_encoder,
+                batch,
+                accelerator.device,
+            )
+            with torch.cuda.amp.autocast(enabled=cfg.amp and accelerator.device.type == "cuda"):
+                outputs = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
+                loss = outputs.loss
+            accelerator.backward(loss)
+            optimizer.step()
+            scheduler.step()
+            optimizer.zero_grad()
+
+        total_loss += loss.item()
+        if step % cfg.logging_steps == 0 and accelerator.is_main_process:
+            print(f"Epoch {epoch} Step {step} Loss {total_loss / step:.4f}")
+    return total_loss / max(step, 1)
+
+
+for epoch in range(cfg.epochs):
+    avg_loss = train_epoch(epoch)
+    if accelerator.is_main_process:
+        print(f"Epoch {epoch} average loss: {avg_loss:.4f}")
+
+#=== Cell 9: Save adapters (PEFT dir) + audio_projector.pt
+if accelerator.is_main_process:
+    adapter_dir = os.path.join(cfg.output_dir, "adapters")
+    projector_path = os.path.join(cfg.output_dir, "audio_projector.pt")
+    os.makedirs(adapter_dir, exist_ok=True)
+    accelerator.unwrap_model(model).save_pretrained(adapter_dir)
+    torch.save(audio_projector.state_dict(), projector_path)
+    print("Saved adapters to", adapter_dir)
+    print("Saved audio projector to", projector_path)
+
+#=== Cell 10: MMLU-Speech evaluation utilities & run (overall accuracy, per-subject, 10 examples)
+
+def generate_from_audio_batch(
+    cfg: CFG,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    audio_features: torch.Tensor,
+    max_new_tokens: int = 64,
+    temperature: float = 0.0,
+):
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        whisper_outputs = whisper_encoder(audio_features.to(device))
+        audio_hidden = whisper_outputs.last_hidden_state
+    audio_tokens = audio_projector(audio_hidden)
+
+    prompts = []
+    for _ in range(audio_features.size(0)):
+        system = cfg.system_prompt
+        user = cfg.user_prompt_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+        prompts.append(f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:")
+
+    encoded = tokenizer(
+        prompts,
+        return_tensors="pt",
+        padding=True,
+        add_special_tokens=False,
+    ).to(device)
+    token_embeds = model.get_input_embeddings()(encoded.input_ids)
+    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+    embeds_list = []
+    mask_list = []
+    for b in range(encoded.input_ids.size(0)):
+        ids = encoded.input_ids[b]
+        embeds = token_embeds[b]
+        seq = []
+        for token_id, token_embed in zip(ids, embeds):
+            if token_id == audio_token_id:
+                seq.append(audio_tokens[b])
+            else:
+                seq.append(token_embed.unsqueeze(0))
+        seq = torch.cat(seq, dim=0)
+        embeds_list.append(seq)
+        mask_list.append(torch.ones(seq.size(0), device=device))
+
+    max_len = max(t.size(0) for t in embeds_list)
+    padded_embeds, padded_masks = [], []
+    for embeds, mask in zip(embeds_list, mask_list):
+        pad_len = max_len - embeds.size(0)
+        if pad_len > 0:
+            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+        padded_embeds.append(embeds)
+        padded_masks.append(mask)
+
+    outputs = model.generate(
+        inputs_embeds=torch.stack(padded_embeds),
+        attention_mask=torch.stack(padded_masks),
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        do_sample=temperature > 0,
+        pad_token_id=tokenizer.pad_token_id,
+        eos_token_id=tokenizer.eos_token_id,
+    )
+    return tokenizer.batch_decode(outputs, skip_special_tokens=True)
+
+
+def evaluate_mmlu_speech(
+    cfg: CFG,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    feature_extractor,
+    max_samples: Optional[int] = None,
+):
+    dataset = load_dataset("mistralai/mmlu_speech", split="validation", cache_dir=cfg.cache_dir)
+    if max_samples:
+        dataset = dataset.select(range(min(len(dataset), max_samples)))
+
+    dataloader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=False)
+    device = next(model.parameters()).device
+
+    total = 0
+    correct = 0
+    per_subject: Dict[str, Dict[str, int]] = {}
+    qualitative = []
+
+    for batch in dataloader:
+        audio_list = []
+        for audio in batch["audio"]:
+            waveform = _resample_audio(audio, cfg.sample_rate)
+            features = feature_extractor(
+                waveform,
+                sampling_rate=cfg.sample_rate,
+                return_tensors="pt",
+            )["input_features"][0]
+            audio_list.append(features)
+        audio_tensor = torch.stack(audio_list).to(device)
+
+        with torch.no_grad():
+            whisper_outputs = whisper_encoder(audio_tensor)
+            audio_hidden = whisper_outputs.last_hidden_state
+        audio_tokens = audio_projector(audio_hidden)
+
+        prompts = []
+        prefix = "Listen to the audio question and select the correct answer (A/B/C/D). Return just the letter."
+        for _ in range(audio_tensor.size(0)):
+            prompts.append(
+                f"SYSTEM: {cfg.system_prompt}\nUSER: {SPECIAL_AUDIO_TOKEN} {prefix} Select the correct option: A, B, C, or D. Reply with one letter.\nASSISTANT:"
+            )
+
+        encoded = tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            add_special_tokens=False,
+        ).to(device)
+        token_embeds = model.get_input_embeddings()(encoded.input_ids)
+        audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+        embeds_list = []
+        mask_list = []
+        for b in range(encoded.input_ids.size(0)):
+            ids = encoded.input_ids[b]
+            embeds = token_embeds[b]
+            seq = []
+            for token_id, token_embed in zip(ids, embeds):
+                if token_id == audio_token_id:
+                    seq.append(audio_tokens[b])
+                else:
+                    seq.append(token_embed.unsqueeze(0))
+            seq = torch.cat(seq, dim=0)
+            embeds_list.append(seq)
+            mask_list.append(torch.ones(seq.size(0), device=device))
+
+        max_len = max(t.size(0) for t in embeds_list)
+        padded_embeds, padded_masks = [], []
+        for embeds, mask in zip(embeds_list, mask_list):
+            pad_len = max_len - embeds.size(0)
+            if pad_len > 0:
+                embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+                mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+            padded_embeds.append(embeds)
+            padded_masks.append(mask)
+
+        outputs = model.generate(
+            inputs_embeds=torch.stack(padded_embeds),
+            attention_mask=torch.stack(padded_masks),
+            max_new_tokens=8,
+            temperature=0.0,
+        )
+        texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        answers = batch["answer"]
+        subjects = batch["subject"]
+        for text, ans, subject in zip(texts, answers, subjects):
+            match = re.search(r"\b([ABCD])\b", text.strip().upper())
+            pred = match.group(1) if match else ""
+            total += 1
+            stats = per_subject.setdefault(subject, {"correct": 0, "total": 0})
+            stats["total"] += 1
+            if pred == ans:
+                correct += 1
+                stats["correct"] += 1
+            if len(qualitative) < 10:
+                qualitative.append({"subject": subject, "prediction": pred, "gold": ans, "raw": text})
+
+    overall_acc = correct / max(total, 1)
+    per_subject_acc = {
+        subject: stats["correct"] / max(stats["total"], 1)
+        for subject, stats in sorted(per_subject.items(), key=lambda item: item[0])
+    }
+    print("MMLU-Speech overall accuracy:", overall_acc)
+    print("Per-subject accuracy (first 5):")
+    for subject, acc in list(per_subject_acc.items())[:5]:
+        print(subject, f"{acc:.3f}")
+    print("Qualitative examples:")
+    for example in qualitative:
+        print(example)
+    return overall_acc, per_subject_acc, qualitative
+
+
+evaluate_mmlu_speech(
+    cfg,
+    model,
+    tokenizer,
+    audio_projector,
+    whisper_encoder,
+    whisper_feature_extractor,
+    cfg.mmlu_speech_max,
+)
+
+#=== Cell 11: Inference helper for a local wav
+
+def transcribe_and_answer(wav_path: str):
+    waveform, sr = sf.read(wav_path)
+    if sr != cfg.sample_rate:
+        waveform = torchaudio.functional.resample(torch.tensor(waveform).float(), sr, cfg.sample_rate).numpy()
+    features = whisper_feature_extractor(
+        waveform,
+        sampling_rate=cfg.sample_rate,
+        return_tensors="pt",
+    )["input_features"].to(next(model.parameters()).device)
+    outputs = generate_from_audio_batch(
+        cfg,
+        model,
+        tokenizer,
+        audio_projector,
+        whisper_encoder,
+        features,
+    )
+    return outputs[0]
+
+
+print("Inference helper ready. Call transcribe_and_answer('path_to_audio.wav').")
+-----END COLAB TEACHER NOTEBOOK-----

--- a/colab_audiochatllama_teacher.py
+++ b/colab_audiochatllama_teacher.py
@@ -69,7 +69,7 @@ class CFG:
     assistant_prefix: str = "Answer:"
     sample_rate: int = 16000
     max_duration_s: float = 12.0
-    n_audio_tokens: int = 12
+    audio_subsample: int = 2
     projector_hidden: int = 1024
     train_max_sft_samples: int = 2000
     val_max_sft_samples: int = 200
@@ -176,32 +176,219 @@ print("Whisper encoder hidden size:", whisper_encoder.config.d_model)
 #=== Cell 4: Define AudioProjector (in_dim = whisper d_model, out_dim = LLM hidden, N tokens)
 
 
-class AudioProjector(nn.Module):
-    def __init__(self, input_dim: int, output_dim: int, n_tokens: int = 12, hidden_dim: Optional[int] = None):
+class AudioSubsamplingProjector(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        subsample_factor: int = 2,
+        hidden_dim: Optional[int] = None,
+    ):
         super().__init__()
+        if subsample_factor < 1:
+            raise ValueError("subsample_factor must be >= 1")
+        self.subsample_factor = subsample_factor
         hidden_dim = hidden_dim or max(input_dim, output_dim)
-        self.n_tokens = n_tokens
-        self.output_dim = output_dim
-        self.net = nn.Sequential(
-            nn.Linear(input_dim, hidden_dim),
-            nn.GELU(),
-            nn.Linear(hidden_dim, n_tokens * output_dim),
-        )
+        self.proj_in = nn.Linear(input_dim, hidden_dim)
+        self.act = nn.GELU()
+        self.proj_out = nn.Linear(hidden_dim, output_dim)
 
     def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
-        pooled = encoder_hidden_states.mean(dim=1)
-        projected = self.net(pooled)
-        projected = projected.view(-1, self.n_tokens, self.output_dim)
-        return projected
+        # encoder_hidden_states: (batch, time, dim)
+        x = encoder_hidden_states
+        if self.subsample_factor > 1:
+            x = x.transpose(1, 2)
+            x = torch.nn.functional.avg_pool1d(
+                x,
+                kernel_size=self.subsample_factor,
+                stride=self.subsample_factor,
+                ceil_mode=True,
+            )
+            x = x.transpose(1, 2)
+        x = self.proj_out(self.act(self.proj_in(x)))
+        return x
 
 
-audio_projector = AudioProjector(
+audio_projector = AudioSubsamplingProjector(
     input_dim=whisper_encoder.config.d_model,
     output_dim=model.config.hidden_size,
-    n_tokens=cfg.n_audio_tokens,
+    subsample_factor=cfg.audio_subsample,
     hidden_dim=cfg.projector_hidden,
 )
 print(audio_projector)
+
+audio_llm = AudioLLMModel(
+    llm=model,
+    whisper_encoder=whisper_encoder,
+    audio_projector=audio_projector,
+    tokenizer=tokenizer,
+    audio_token=SPECIAL_AUDIO_TOKEN,
+)
+
+
+class AudioLLMModel(nn.Module):
+    def __init__(
+        self,
+        llm: AutoModelForCausalLM,
+        whisper_encoder: WhisperModel,
+        audio_projector: nn.Module,
+        tokenizer,
+        audio_token: str,
+    ):
+        super().__init__()
+        self.llm = llm
+        self.whisper_encoder = whisper_encoder
+        self.audio_projector = audio_projector
+        self.tokenizer = tokenizer
+        self.audio_token_id = tokenizer.convert_tokens_to_ids(audio_token)
+
+    def unwrap(self, module: nn.Module) -> nn.Module:
+        return getattr(module, "module", module)
+
+    def _input_embedding_layer(self):
+        return self.unwrap(self.llm).get_input_embeddings()
+
+    def encode_audio(self, input_features: torch.Tensor) -> torch.Tensor:
+        device = next(self.llm.parameters()).device
+        input_features = input_features.to(device)
+        with torch.no_grad():
+            outputs = self.whisper_encoder(input_features)
+        return outputs.last_hidden_state
+
+    def project_audio(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        projected = self.audio_projector(encoder_hidden_states)
+        embed_dtype = self._input_embedding_layer().weight.dtype
+        return projected.to(embed_dtype)
+
+    def trainable_parameters(self):
+        for module in (self.llm, self.audio_projector):
+            for param in module.parameters():
+                if param.requires_grad:
+                    yield param
+
+    def _merge_sequences(
+        self,
+        input_ids: torch.Tensor,
+        token_embeds: torch.Tensor,
+        audio_embeddings: torch.Tensor,
+        labels: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        batch_embeds: List[torch.Tensor] = []
+        batch_masks: List[torch.Tensor] = []
+        batch_labels: List[torch.Tensor] = [] if labels is not None else None
+
+        for idx in range(input_ids.size(0)):
+            seq_embeds: List[torch.Tensor] = []
+            seq_mask: List[torch.Tensor] = []
+            seq_labels: List[torch.Tensor] = [] if labels is not None else None
+            audio_seq = audio_embeddings[idx]
+            label_seq = labels[idx] if labels is not None else None
+            audio_inserted = False
+
+            for token_position, (token_id, embed) in enumerate(zip(input_ids[idx], token_embeds[idx])):
+                if token_id.item() == self.audio_token_id:
+                    seq_embeds.append(audio_seq)
+                    seq_mask.append(torch.ones(audio_seq.size(0), device=embed.device, dtype=torch.long))
+                    if labels is not None:
+                        seq_labels.append(
+                            torch.full((audio_seq.size(0),), -100, device=embed.device, dtype=torch.long)
+                        )
+                    audio_inserted = True
+                else:
+                    seq_embeds.append(embed.unsqueeze(0))
+                    seq_mask.append(torch.ones(1, device=embed.device, dtype=torch.long))
+                    if labels is not None:
+                        seq_labels.append(label_seq[token_position].view(1))
+
+            if not audio_inserted:
+                raise ValueError("Input sequence is missing the audio special token.")
+
+            seq_embeds_tensor = torch.cat(seq_embeds, dim=0)
+            seq_mask_tensor = torch.cat(seq_mask, dim=0)
+            batch_embeds.append(seq_embeds_tensor)
+            batch_masks.append(seq_mask_tensor)
+            if labels is not None and seq_labels is not None:
+                seq_labels_tensor = torch.cat(seq_labels, dim=0)
+                batch_labels.append(seq_labels_tensor)
+
+        padded_embeds = torch.nn.utils.rnn.pad_sequence(batch_embeds, batch_first=True)
+        padded_masks = torch.nn.utils.rnn.pad_sequence(batch_masks, batch_first=True)
+        padded_labels = None
+        if batch_labels is not None:
+            padded_labels = torch.nn.utils.rnn.pad_sequence(batch_labels, batch_first=True, padding_value=-100)
+        return padded_embeds, padded_masks, padded_labels
+
+    def prepare_inputs_and_labels(
+        self,
+        batch: Dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        input_features = batch["input_features"].to(device)
+        input_ids = batch["input_ids"].to(device)
+        loss_mask = batch["loss_mask"].to(device)
+
+        audio_hidden = self.encode_audio(input_features)
+        audio_embeddings = self.project_audio(audio_hidden)
+        embedding_layer = self._input_embedding_layer()
+        token_embeds = embedding_layer(input_ids)
+        labels = input_ids.clone()
+        labels[loss_mask == 0] = -100
+        inputs_embeds, attention_mask, labels = self._merge_sequences(
+            input_ids,
+            token_embeds,
+            audio_embeddings,
+            labels,
+        )
+        return inputs_embeds, attention_mask, labels
+
+    def prepare_generation_inputs(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        encoded = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            add_special_tokens=False,
+        ).to(device)
+
+        audio_hidden = self.encode_audio(audio_features.to(device))
+        audio_embeddings = self.project_audio(audio_hidden)
+        token_embeds = self._input_embedding_layer()(encoded.input_ids)
+        inputs_embeds, attention_mask, _ = self._merge_sequences(
+            encoded.input_ids,
+            token_embeds,
+            audio_embeddings,
+        )
+        return inputs_embeds, attention_mask
+
+    def generate(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        generation_kwargs = generation_kwargs or {}
+        model = self.unwrap(self.llm)
+        device = next(self.llm.parameters()).device
+        inputs_embeds, attention_mask = self.prepare_generation_inputs(
+            prompts,
+            audio_features,
+            device,
+        )
+        default_kwargs = {
+            "pad_token_id": self.tokenizer.pad_token_id,
+            "eos_token_id": self.tokenizer.eos_token_id,
+        }
+        default_kwargs.update(generation_kwargs)
+        outputs = model.generate(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            **default_kwargs,
+        )
+        return self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
 #=== Cell 5: Dataset loaders with SpokenWOZ + optional fallbacks
 
@@ -354,66 +541,11 @@ collator = SFTCollator(tokenizer, cfg)
 
 def make_inputs_embeds_and_labels(
     cfg: CFG,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     batch: Dict[str, torch.Tensor],
     device: torch.device,
 ):
-    input_features = batch["input_features"].to(device)
-    input_ids = batch["input_ids"].to(device)
-    loss_mask = batch["loss_mask"].to(device)
-
-    with torch.no_grad():
-        whisper_outputs = whisper_encoder(input_features)
-        audio_hidden = whisper_outputs.last_hidden_state
-    audio_tokens = audio_projector(audio_hidden)
-
-    token_embeds = model.get_input_embeddings()(input_ids)
-    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-    expanded_embeds = []
-    expanded_labels = []
-    expanded_masks = []
-    for b in range(input_ids.size(0)):
-        ids = input_ids[b]
-        embeds = token_embeds[b]
-        labels = ids.clone()
-        labels[loss_mask[b] == 0] = -100
-        seq_embeds = []
-        seq_labels = []
-        seq_mask = []
-        for token_id, token_embed, label in zip(ids, embeds, labels):
-            if token_id == audio_token_id:
-                for j in range(audio_projector.n_audio_tokens):
-                    seq_embeds.append(audio_tokens[b, j])
-                    seq_labels.append(torch.tensor(-100, device=device))
-                    seq_mask.append(torch.tensor(1, device=device))
-            else:
-                seq_embeds.append(token_embed)
-                seq_labels.append(label)
-                seq_mask.append(torch.tensor(1, device=device))
-        seq_embeds = torch.stack(seq_embeds)
-        seq_labels = torch.stack(seq_labels)
-        seq_mask = torch.stack(seq_mask)
-        expanded_embeds.append(seq_embeds)
-        expanded_labels.append(seq_labels)
-        expanded_masks.append(seq_mask)
-
-    max_len = max(t.size(0) for t in expanded_embeds)
-    padded_embeds, padded_labels, padded_masks = [], [], []
-    for embeds, labels, mask in zip(expanded_embeds, expanded_labels, expanded_masks):
-        pad_len = max_len - embeds.size(0)
-        if pad_len > 0:
-            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-            labels = torch.cat([labels, torch.full((pad_len,), -100, device=device, dtype=torch.long)], dim=0)
-            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-        padded_embeds.append(embeds)
-        padded_labels.append(labels)
-        padded_masks.append(mask)
-
-    return torch.stack(padded_embeds), torch.stack(padded_masks), torch.stack(padded_labels)
+    return audio_model.prepare_inputs_and_labels(batch, device)
 
 
 #=== Cell 8: Training loop (loss prints every N steps)
@@ -426,7 +558,7 @@ train_loader = DataLoader(
     num_workers=cfg.num_workers,
 )
 optimizer = AdamW(
-    list(model.parameters()) + list(audio_projector.parameters()),
+    list(audio_llm.trainable_parameters()),
     lr=cfg.lr,
     weight_decay=cfg.weight_decay,
 )
@@ -436,29 +568,35 @@ scheduler = get_linear_schedule_with_warmup(
     num_warmup_steps=int(cfg.warmup_ratio * num_training_steps),
     num_training_steps=num_training_steps,
 )
-model, optimizer, train_loader, scheduler = accelerator.prepare(model, optimizer, train_loader, scheduler)
-audio_projector = audio_projector.to(accelerator.device)
-whisper_encoder = whisper_encoder.to(accelerator.device)
+
+prepared_llm, prepared_projector, optimizer, train_loader, scheduler = accelerator.prepare(
+    audio_llm.llm,
+    audio_llm.audio_projector,
+    optimizer,
+    train_loader,
+    scheduler,
+)
+audio_llm.llm = prepared_llm
+audio_llm.audio_projector = prepared_projector
+audio_llm.whisper_encoder = audio_llm.whisper_encoder.to(accelerator.device)
+audio_llm.whisper_encoder.eval()
 
 def train_epoch(epoch: int):
-    model.train()
-    audio_projector.train()
+    audio_llm.llm.train()
+    audio_llm.audio_projector.train()
     total_loss = 0.0
     scaler = torch.cuda.amp.GradScaler(enabled=cfg.amp and accelerator.device.type == "cuda")
 
     for step, batch in enumerate(train_loader, start=1):
-        with accelerator.accumulate(model):
+        with accelerator.accumulate(audio_llm.llm):
             inputs_embeds, attention_mask, labels = make_inputs_embeds_and_labels(
                 cfg,
-                model,
-                tokenizer,
-                audio_projector,
-                whisper_encoder,
+                audio_llm,
                 batch,
                 accelerator.device,
             )
             with torch.cuda.amp.autocast(enabled=cfg.amp and accelerator.device.type == "cuda"):
-                outputs = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
+                outputs = audio_llm.llm(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
                 loss = outputs.loss
             accelerator.backward(loss)
             optimizer.step()
@@ -473,16 +611,18 @@ def train_epoch(epoch: int):
 
 for epoch in range(cfg.epochs):
     avg_loss = train_epoch(epoch)
-    if accelerator.is_main_process:
-        print(f"Epoch {epoch} average loss: {avg_loss:.4f}")
+if accelerator.is_main_process:
+    print(f"Epoch {epoch} average loss: {avg_loss:.4f}")
 
 #=== Cell 9: Save adapters (PEFT dir) + audio_projector.pt
 if accelerator.is_main_process:
     adapter_dir = os.path.join(cfg.output_dir, "adapters")
     projector_path = os.path.join(cfg.output_dir, "audio_projector.pt")
     os.makedirs(adapter_dir, exist_ok=True)
-    accelerator.unwrap_model(model).save_pretrained(adapter_dir)
-    torch.save(audio_projector.state_dict(), projector_path)
+    base_model = accelerator.unwrap_model(audio_llm.llm)
+    base_model.save_pretrained(adapter_dir)
+    projector_to_save = accelerator.unwrap_model(audio_llm.audio_projector)
+    torch.save(projector_to_save.state_dict(), projector_path)
     print("Saved adapters to", adapter_dir)
     print("Saved audio projector to", projector_path)
 
@@ -490,78 +630,28 @@ if accelerator.is_main_process:
 
 def generate_from_audio_batch(
     cfg: CFG,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     audio_features: torch.Tensor,
     max_new_tokens: int = 64,
     temperature: float = 0.0,
 ):
-    device = next(model.parameters()).device
-    with torch.no_grad():
-        whisper_outputs = whisper_encoder(audio_features.to(device))
-        audio_hidden = whisper_outputs.last_hidden_state
-    audio_tokens = audio_projector(audio_hidden)
-
     prompts = []
     for _ in range(audio_features.size(0)):
         system = cfg.system_prompt
         user = cfg.user_prompt_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
         prompts.append(f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:")
 
-    encoded = tokenizer(
-        prompts,
-        return_tensors="pt",
-        padding=True,
-        add_special_tokens=False,
-    ).to(device)
-    token_embeds = model.get_input_embeddings()(encoded.input_ids)
-    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-    embeds_list = []
-    mask_list = []
-    for b in range(encoded.input_ids.size(0)):
-        ids = encoded.input_ids[b]
-        embeds = token_embeds[b]
-        seq = []
-        for token_id, token_embed in zip(ids, embeds):
-            if token_id == audio_token_id:
-                seq.append(audio_tokens[b])
-            else:
-                seq.append(token_embed.unsqueeze(0))
-        seq = torch.cat(seq, dim=0)
-        embeds_list.append(seq)
-        mask_list.append(torch.ones(seq.size(0), device=device))
-
-    max_len = max(t.size(0) for t in embeds_list)
-    padded_embeds, padded_masks = [], []
-    for embeds, mask in zip(embeds_list, mask_list):
-        pad_len = max_len - embeds.size(0)
-        if pad_len > 0:
-            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-        padded_embeds.append(embeds)
-        padded_masks.append(mask)
-
-    outputs = model.generate(
-        inputs_embeds=torch.stack(padded_embeds),
-        attention_mask=torch.stack(padded_masks),
-        max_new_tokens=max_new_tokens,
-        temperature=temperature,
-        do_sample=temperature > 0,
-        pad_token_id=tokenizer.pad_token_id,
-        eos_token_id=tokenizer.eos_token_id,
-    )
-    return tokenizer.batch_decode(outputs, skip_special_tokens=True)
+    generation_kwargs = {
+        "max_new_tokens": max_new_tokens,
+        "temperature": temperature,
+        "do_sample": temperature > 0,
+    }
+    return audio_model.generate(prompts, audio_features, generation_kwargs)
 
 
 def evaluate_mmlu_speech(
     cfg: CFG,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     feature_extractor,
     max_samples: Optional[int] = None,
 ):
@@ -570,7 +660,6 @@ def evaluate_mmlu_speech(
         dataset = dataset.select(range(min(len(dataset), max_samples)))
 
     dataloader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=False)
-    device = next(model.parameters()).device
 
     total = 0
     correct = 0
@@ -586,13 +675,8 @@ def evaluate_mmlu_speech(
                 sampling_rate=cfg.sample_rate,
                 return_tensors="pt",
             )["input_features"][0]
-            audio_list.append(features)
-        audio_tensor = torch.stack(audio_list).to(device)
-
-        with torch.no_grad():
-            whisper_outputs = whisper_encoder(audio_tensor)
-            audio_hidden = whisper_outputs.last_hidden_state
-        audio_tokens = audio_projector(audio_hidden)
+            audio_list.append(features.to(torch.float32))
+        audio_tensor = torch.stack(audio_list)
 
         prompts = []
         prefix = "Listen to the audio question and select the correct answer (A/B/C/D). Return just the letter."
@@ -601,47 +685,11 @@ def evaluate_mmlu_speech(
                 f"SYSTEM: {cfg.system_prompt}\nUSER: {SPECIAL_AUDIO_TOKEN} {prefix} Select the correct option: A, B, C, or D. Reply with one letter.\nASSISTANT:"
             )
 
-        encoded = tokenizer(
+        texts = audio_model.generate(
             prompts,
-            return_tensors="pt",
-            padding=True,
-            add_special_tokens=False,
-        ).to(device)
-        token_embeds = model.get_input_embeddings()(encoded.input_ids)
-        audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-        embeds_list = []
-        mask_list = []
-        for b in range(encoded.input_ids.size(0)):
-            ids = encoded.input_ids[b]
-            embeds = token_embeds[b]
-            seq = []
-            for token_id, token_embed in zip(ids, embeds):
-                if token_id == audio_token_id:
-                    seq.append(audio_tokens[b])
-                else:
-                    seq.append(token_embed.unsqueeze(0))
-            seq = torch.cat(seq, dim=0)
-            embeds_list.append(seq)
-            mask_list.append(torch.ones(seq.size(0), device=device))
-
-        max_len = max(t.size(0) for t in embeds_list)
-        padded_embeds, padded_masks = [], []
-        for embeds, mask in zip(embeds_list, mask_list):
-            pad_len = max_len - embeds.size(0)
-            if pad_len > 0:
-                embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-                mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-            padded_embeds.append(embeds)
-            padded_masks.append(mask)
-
-        outputs = model.generate(
-            inputs_embeds=torch.stack(padded_embeds),
-            attention_mask=torch.stack(padded_masks),
-            max_new_tokens=8,
-            temperature=0.0,
+            audio_tensor,
+            {"max_new_tokens": 8, "temperature": 0.0, "do_sample": False},
         )
-        texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         answers = batch["answer"]
         subjects = batch["subject"]
         for text, ans, subject in zip(texts, answers, subjects):
@@ -673,10 +721,7 @@ def evaluate_mmlu_speech(
 
 evaluate_mmlu_speech(
     cfg,
-    model,
-    tokenizer,
-    audio_projector,
-    whisper_encoder,
+    audio_llm,
     whisper_feature_extractor,
     cfg.mmlu_speech_max,
 )
@@ -691,13 +736,10 @@ def transcribe_and_answer(wav_path: str):
         waveform,
         sampling_rate=cfg.sample_rate,
         return_tensors="pt",
-    )["input_features"].to(next(model.parameters()).device)
+    )["input_features"]
     outputs = generate_from_audio_batch(
         cfg,
-        model,
-        tokenizer,
-        audio_projector,
-        whisper_encoder,
+        audio_llm,
         features,
     )
     return outputs[0]

--- a/train.py
+++ b/train.py
@@ -81,7 +81,7 @@ class TrainingConfig:
     save_every: int = 200
     resume: Optional[str] = None
     projector_dim: int = 1024
-    n_audio_tokens: int = 12
+    audio_subsample: int = 2
     sample_rate: int = 16000
     max_duration_s: float = 12.0
     warmup_ratio: float = 0.03
@@ -127,7 +127,7 @@ def parse_args() -> TrainingConfig:
     parser.add_argument("--save-every", type=int, default=200)
     parser.add_argument("--resume", type=str, default=None, help="Path to directory with adapters/audio_projector.pt")
     parser.add_argument("--projector-dim", type=int, default=1024)
-    parser.add_argument("--n-audio-tokens", type=int, default=12)
+    parser.add_argument("--audio-subsample", type=int, default=2)
     parser.add_argument("--sample-rate", type=int, default=16000)
     parser.add_argument("--max-duration-s", type=float, default=12.0)
     parser.add_argument("--warmup-ratio", type=float, default=0.03)
@@ -163,7 +163,7 @@ def parse_args() -> TrainingConfig:
         save_every=args.save_every,
         resume=args.resume,
         projector_dim=args.projector_dim,
-        n_audio_tokens=args.n_audio_tokens,
+        audio_subsample=args.audio_subsample,
         sample_rate=args.sample_rate,
         max_duration_s=args.max_duration_s,
         warmup_ratio=args.warmup_ratio,
@@ -259,23 +259,196 @@ def load_frozen_whisper_encoder(cfg: TrainingConfig):
     return whisper.encoder, feature_extractor
 
 
-class AudioProjector(nn.Module):
-    def __init__(self, input_dim: int, output_dim: int, n_tokens: int, hidden_dim: int):
+class AudioSubsamplingProjector(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, subsample_factor: int, hidden_dim: int):
         super().__init__()
-        self.n_tokens = n_tokens
+        if subsample_factor < 1:
+            raise ValueError("subsample_factor must be >= 1")
+        self.subsample_factor = subsample_factor
         hidden_dim = hidden_dim or max(input_dim, output_dim)
-        self.net = nn.Sequential(
-            nn.Linear(input_dim, hidden_dim),
-            nn.GELU(),
-            nn.Linear(hidden_dim, n_tokens * output_dim),
-        )
+        self.proj_in = nn.Linear(input_dim, hidden_dim)
+        self.act = nn.GELU()
+        self.proj_out = nn.Linear(hidden_dim, output_dim)
         self.output_dim = output_dim
 
     def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
-        pooled = encoder_hidden_states.mean(dim=1)
-        projected = self.net(pooled)
-        projected = projected.view(-1, self.n_tokens, self.output_dim)
-        return projected
+        x = encoder_hidden_states
+        if self.subsample_factor > 1:
+            x = x.transpose(1, 2)
+            x = torch.nn.functional.avg_pool1d(
+                x,
+                kernel_size=self.subsample_factor,
+                stride=self.subsample_factor,
+                ceil_mode=True,
+            )
+            x = x.transpose(1, 2)
+        x = self.proj_out(self.act(self.proj_in(x)))
+        return x
+
+
+class AudioLLMModel(nn.Module):
+    def __init__(
+        self,
+        llm: AutoModelForCausalLM,
+        whisper_encoder: WhisperModel,
+        audio_projector: nn.Module,
+        tokenizer,
+        audio_token: str,
+    ):
+        super().__init__()
+        self.llm = llm
+        self.whisper_encoder = whisper_encoder
+        self.audio_projector = audio_projector
+        self.tokenizer = tokenizer
+        self.audio_token_id = tokenizer.convert_tokens_to_ids(audio_token)
+
+    def unwrap(self, module: nn.Module) -> nn.Module:
+        return getattr(module, "module", module)
+
+    def _input_embedding_layer(self):
+        return self.unwrap(self.llm).get_input_embeddings()
+
+    def encode_audio(self, input_features: torch.Tensor) -> torch.Tensor:
+        device = next(self.llm.parameters()).device
+        input_features = input_features.to(device)
+        with torch.no_grad():
+            outputs = self.whisper_encoder(input_features)
+        return outputs.last_hidden_state
+
+    def project_audio(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        projected = self.audio_projector(encoder_hidden_states)
+        embed_dtype = self._input_embedding_layer().weight.dtype
+        return projected.to(embed_dtype)
+
+    def trainable_parameters(self):
+        for module in (self.llm, self.audio_projector):
+            for param in module.parameters():
+                if param.requires_grad:
+                    yield param
+
+    def _merge_sequences(
+        self,
+        input_ids: torch.Tensor,
+        token_embeds: torch.Tensor,
+        audio_embeddings: torch.Tensor,
+        labels: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        batch_embeds: List[torch.Tensor] = []
+        batch_masks: List[torch.Tensor] = []
+        batch_labels: List[torch.Tensor] = [] if labels is not None else None
+
+        for idx in range(input_ids.size(0)):
+            seq_embeds: List[torch.Tensor] = []
+            seq_mask: List[torch.Tensor] = []
+            seq_labels: List[torch.Tensor] = [] if labels is not None else None
+            audio_seq = audio_embeddings[idx]
+            label_seq = labels[idx] if labels is not None else None
+            audio_inserted = False
+
+            for token_position, (token_id, embed) in enumerate(zip(input_ids[idx], token_embeds[idx])):
+                if token_id.item() == self.audio_token_id:
+                    seq_embeds.append(audio_seq)
+                    seq_mask.append(torch.ones(audio_seq.size(0), device=embed.device, dtype=torch.long))
+                    if labels is not None:
+                        seq_labels.append(
+                            torch.full((audio_seq.size(0),), -100, device=embed.device, dtype=torch.long)
+                        )
+                    audio_inserted = True
+                else:
+                    seq_embeds.append(embed.unsqueeze(0))
+                    seq_mask.append(torch.ones(1, device=embed.device, dtype=torch.long))
+                    if labels is not None:
+                        seq_labels.append(label_seq[token_position].view(1))
+
+            if not audio_inserted:
+                raise ValueError("Input sequence is missing the audio special token.")
+
+            seq_embeds_tensor = torch.cat(seq_embeds, dim=0)
+            seq_mask_tensor = torch.cat(seq_mask, dim=0)
+            batch_embeds.append(seq_embeds_tensor)
+            batch_masks.append(seq_mask_tensor)
+            if labels is not None and seq_labels is not None:
+                seq_labels_tensor = torch.cat(seq_labels, dim=0)
+                batch_labels.append(seq_labels_tensor)
+
+        padded_embeds = torch.nn.utils.rnn.pad_sequence(batch_embeds, batch_first=True)
+        padded_masks = torch.nn.utils.rnn.pad_sequence(batch_masks, batch_first=True)
+        padded_labels = None
+        if batch_labels is not None:
+            padded_labels = torch.nn.utils.rnn.pad_sequence(batch_labels, batch_first=True, padding_value=-100)
+        return padded_embeds, padded_masks, padded_labels
+
+    def prepare_inputs_and_labels(
+        self,
+        batch: Dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        input_features = batch["input_features"].to(device)
+        input_ids = batch["input_ids"].to(device)
+        loss_mask = batch["loss_mask"].to(device)
+
+        audio_hidden = self.encode_audio(input_features)
+        audio_embeddings = self.project_audio(audio_hidden)
+        embedding_layer = self._input_embedding_layer()
+        token_embeds = embedding_layer(input_ids)
+        labels = input_ids.clone()
+        labels[loss_mask == 0] = -100
+        inputs_embeds, attention_mask, labels = self._merge_sequences(
+            input_ids,
+            token_embeds,
+            audio_embeddings,
+            labels,
+        )
+        return inputs_embeds, attention_mask, labels
+
+    def prepare_generation_inputs(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        encoded = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            add_special_tokens=False,
+        ).to(device)
+
+        audio_hidden = self.encode_audio(audio_features.to(device))
+        audio_embeddings = self.project_audio(audio_hidden)
+        token_embeds = self._input_embedding_layer()(encoded.input_ids)
+        inputs_embeds, attention_mask, _ = self._merge_sequences(
+            encoded.input_ids,
+            token_embeds,
+            audio_embeddings,
+        )
+        return inputs_embeds, attention_mask
+
+    def generate(
+        self,
+        prompts: List[str],
+        audio_features: torch.Tensor,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        generation_kwargs = generation_kwargs or {}
+        model = self.unwrap(self.llm)
+        device = next(self.llm.parameters()).device
+        inputs_embeds, attention_mask = self.prepare_generation_inputs(
+            prompts,
+            audio_features,
+            device,
+        )
+        default_kwargs = {
+            "pad_token_id": self.tokenizer.pad_token_id,
+            "eos_token_id": self.tokenizer.eos_token_id,
+        }
+        default_kwargs.update(generation_kwargs)
+        outputs = model.generate(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            **default_kwargs,
+        )
+        return self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
 
 # ---------------------------------------------------------------------------
@@ -415,71 +588,11 @@ class SFTCollator:
 
 def make_inputs_embeds_and_labels(
     cfg: TrainingConfig,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     batch: Dict[str, torch.Tensor],
     device: torch.device,
 ):
-    input_features = batch["input_features"].to(device)
-    input_ids = batch["input_ids"].to(device)
-    loss_mask = batch["loss_mask"].to(device)
-
-    with torch.no_grad():
-        whisper_outputs = whisper_encoder(input_features)
-        audio_hidden = whisper_outputs.last_hidden_state
-    audio_tokens = audio_projector(audio_hidden)
-
-    token_embeds = model.get_input_embeddings()(input_ids)
-    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-    expanded_embeds = []
-    expanded_labels = []
-    expanded_masks = []
-    for b in range(input_ids.size(0)):
-        ids = input_ids[b]
-        embeds = token_embeds[b]
-        labels = ids.clone()
-        labels[loss_mask[b] == 0] = -100
-        seq_embeds: List[torch.Tensor] = []
-        seq_labels: List[torch.Tensor] = []
-        seq_mask: List[torch.Tensor] = []
-        inserted = 0
-        for idx, (token_id, token_embed, label_val) in enumerate(zip(ids, embeds, labels)):
-            if token_id == audio_token_id:
-                for j in range(audio_projector.n_audio_tokens):
-                    seq_embeds.append(audio_tokens[b, j])
-                    seq_labels.append(torch.tensor(-100, device=device))
-                    seq_mask.append(torch.tensor(1, device=device))
-                inserted += 1
-            else:
-                seq_embeds.append(token_embed)
-                seq_labels.append(label_val)
-                seq_mask.append(torch.tensor(1, device=device))
-        seq_embeds = torch.stack(seq_embeds)
-        seq_labels = torch.stack(seq_labels)
-        seq_mask = torch.stack(seq_mask)
-        expanded_embeds.append(seq_embeds)
-        expanded_labels.append(seq_labels)
-        expanded_masks.append(seq_mask)
-
-    max_len = max(t.size(0) for t in expanded_embeds)
-    padded_embeds, padded_labels, padded_masks = [], [], []
-    for embeds, labels, mask in zip(expanded_embeds, expanded_labels, expanded_masks):
-        pad_len = max_len - embeds.size(0)
-        if pad_len > 0:
-            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-            labels = torch.cat([labels, torch.full((pad_len,), -100, device=device, dtype=torch.long)])
-            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-        padded_embeds.append(embeds)
-        padded_labels.append(labels)
-        padded_masks.append(mask)
-
-    inputs_embeds = torch.stack(padded_embeds)
-    attention_mask = torch.stack(padded_masks)
-    labels = torch.stack(padded_labels)
-    return inputs_embeds, attention_mask, labels
+    return audio_model.prepare_inputs_and_labels(batch, device)
 
 
 # ---------------------------------------------------------------------------
@@ -489,10 +602,7 @@ def make_inputs_embeds_and_labels(
 
 def train_epoch(
     cfg: TrainingConfig,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     dataloader: DataLoader,
     optimizer: torch.optim.Optimizer,
     scheduler,
@@ -500,24 +610,21 @@ def train_epoch(
     epoch: int,
     scaler: Optional[torch.cuda.amp.GradScaler] = None,
 ):
-    model.train()
-    audio_projector.train()
+    audio_model.llm.train()
+    audio_model.audio_projector.train()
     total_loss = 0.0
     step = 0
 
     for batch_idx, batch in enumerate(dataloader):
         inputs_embeds, attention_mask, labels = make_inputs_embeds_and_labels(
             cfg,
-            model,
-            tokenizer,
-            audio_projector,
-            whisper_encoder,
+            audio_model,
             batch,
             device,
         )
 
         with torch.cuda.amp.autocast(enabled=cfg.amp and device.type == "cuda"):
-            outputs = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
+            outputs = audio_model.llm(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
             loss = outputs.loss / cfg.grad_accum
 
         if scaler is not None:
@@ -529,8 +636,8 @@ def train_epoch(
             if scaler is not None:
                 scaler.unscale_(optimizer)
             if cfg.clip_grad_norm is not None:
-                torch.nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad_norm)
-                torch.nn.utils.clip_grad_norm_(audio_projector.parameters(), cfg.clip_grad_norm)
+                torch.nn.utils.clip_grad_norm_(audio_model.llm.parameters(), cfg.clip_grad_norm)
+                torch.nn.utils.clip_grad_norm_(audio_model.audio_projector.parameters(), cfg.clip_grad_norm)
             if scaler is not None:
                 scaler.step(optimizer)
                 scaler.update()
@@ -547,7 +654,7 @@ def train_epoch(
     return total_loss / max(step, 1)
 
 
-def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper_encoder, train_dataset):
+def run_training(cfg: TrainingConfig, audio_model: AudioLLMModel, tokenizer, train_dataset):
     sampler = None
     if cfg.ddp and dist.is_initialized():
         sampler = DistributedSampler(train_dataset, shuffle=True)
@@ -562,7 +669,7 @@ def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper
     )
 
     optimizer = AdamW(
-        list(model.parameters()) + list(audio_projector.parameters()),
+        list(audio_model.trainable_parameters()),
         lr=cfg.lr,
         weight_decay=cfg.weight_decay,
     )
@@ -574,7 +681,7 @@ def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper
     )
 
     scaler = torch.cuda.amp.GradScaler(enabled=cfg.amp and torch.cuda.is_available())
-    device = next(model.parameters()).device
+    device = next(audio_model.llm.parameters()).device
 
     global_step = 0
     best_loss = float("inf")
@@ -583,10 +690,7 @@ def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper
             sampler.set_epoch(epoch)
         avg_loss = train_epoch(
             cfg,
-            model,
-            tokenizer,
-            audio_projector,
-            whisper_encoder,
+            audio_model,
             dataloader,
             optimizer,
             scheduler,
@@ -599,7 +703,7 @@ def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper
         best_loss = min(best_loss, avg_loss)
         global_step += len(dataloader)
         if is_main_process():
-            save_checkpoint(cfg, model, audio_projector, global_step, avg_loss, best_loss)
+            save_checkpoint(cfg, audio_model, global_step, avg_loss, best_loss)
     return best_loss
 
 
@@ -610,78 +714,29 @@ def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper
 
 def generate_from_audio_batch(
     cfg: TrainingConfig,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     audio_features: torch.Tensor,
     max_new_tokens: int = 64,
     temperature: float = 0.0,
 ):
-    device = next(model.parameters()).device
-    with torch.no_grad():
-        whisper_outputs = whisper_encoder(audio_features.to(device))
-        audio_hidden = whisper_outputs.last_hidden_state
-    audio_tokens = audio_projector(audio_hidden)
-
     prompts = []
     for _ in range(audio_features.size(0)):
         system = cfg.system_prompt
         user = cfg.user_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
         prompts.append(f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:")
 
-    encoded = tokenizer(prompts, return_tensors="pt", padding=True, add_special_tokens=False).to(device)
-    token_embeds = model.get_input_embeddings()(encoded.input_ids)
-    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-    embeds_list = []
-    mask_list = []
-    for b in range(encoded.input_ids.size(0)):
-        ids = encoded.input_ids[b]
-        embeds = token_embeds[b]
-        seq = []
-        for token_id, token_embed in zip(ids, embeds):
-            if token_id == audio_token_id:
-                seq.append(audio_tokens[b])
-            else:
-                seq.append(token_embed.unsqueeze(0))
-        seq = torch.cat(seq, dim=0)
-        embeds_list.append(seq)
-        mask_list.append(torch.ones(seq.size(0), device=device))
-
-    max_len = max(t.size(0) for t in embeds_list)
-    padded_embeds = []
-    padded_masks = []
-    for embeds, mask in zip(embeds_list, mask_list):
-        pad_len = max_len - embeds.size(0)
-        if pad_len > 0:
-            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-        padded_embeds.append(embeds)
-        padded_masks.append(mask)
-
-    inputs_embeds = torch.stack(padded_embeds)
-    attention_mask = torch.stack(padded_masks)
-
-    outputs = model.generate(
-        inputs_embeds=inputs_embeds,
-        attention_mask=attention_mask,
-        max_new_tokens=max_new_tokens,
-        temperature=temperature,
-        do_sample=temperature > 0,
-        pad_token_id=tokenizer.pad_token_id,
-        eos_token_id=tokenizer.eos_token_id,
-    )
-    texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+    generation_kwargs = {
+        "max_new_tokens": max_new_tokens,
+        "temperature": temperature,
+        "do_sample": temperature > 0,
+    }
+    texts = audio_model.generate(prompts, audio_features, generation_kwargs)
     return texts
 
 
 def evaluate_mmlu_speech(
     cfg: TrainingConfig,
-    model: AutoModelForCausalLM,
-    tokenizer,
-    audio_projector: AudioProjector,
-    whisper_encoder,
+    audio_model: AudioLLMModel,
     feature_extractor,
     max_samples: Optional[int] = None,
 ):
@@ -690,7 +745,6 @@ def evaluate_mmlu_speech(
         dataset = dataset.select(range(min(len(dataset), max_samples)))
 
     dataloader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=False)
-    device = next(model.parameters()).device
 
     total = 0
     correct = 0
@@ -706,64 +760,27 @@ def evaluate_mmlu_speech(
                 sampling_rate=cfg.sample_rate,
                 return_tensors="pt",
             )["input_features"][0]
-            audio_list.append(feats)
-        audio_tensor = torch.stack(audio_list).to(device)
-        with torch.no_grad():
-            whisper_outputs = whisper_encoder(audio_tensor)
-            audio_hidden = whisper_outputs.last_hidden_state
-        audio_tokens = audio_projector(audio_hidden)
+            audio_list.append(feats.to(torch.float32))
+        audio_tensor = torch.stack(audio_list)
 
         prompts = []
         prefix = "Listen to the audio question and select the correct answer (A/B/C/D). Return just the letter."
         for _ in range(audio_tensor.size(0)):
             prompts.append(
-                f"SYSTEM: {cfg.system_prompt}\nUSER: {SPECIAL_AUDIO_TOKEN} {prefix} Select the correct option: A, B, C, or D. Reply with one letter.\nASSISTANT:"
+                f"SYSTEM: {cfg.system_prompt}
+USER: {SPECIAL_AUDIO_TOKEN} {prefix} Select the correct option: A, B, C, or D. Reply with one letter.
+ASSISTANT:"
             )
 
-        encoded = tokenizer(prompts, return_tensors="pt", padding=True, add_special_tokens=False).to(device)
-        token_embeds = model.get_input_embeddings()(encoded.input_ids)
-        audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
-
-        embeds_list = []
-        mask_list = []
-        for b in range(encoded.input_ids.size(0)):
-            ids = encoded.input_ids[b]
-            embeds = token_embeds[b]
-            seq = []
-            for token_id, token_embed in zip(ids, embeds):
-                if token_id == audio_token_id:
-                    seq.append(audio_tokens[b])
-                else:
-                    seq.append(token_embed.unsqueeze(0))
-            seq = torch.cat(seq, dim=0)
-            embeds_list.append(seq)
-            mask_list.append(torch.ones(seq.size(0), device=device))
-
-        max_len = max(t.size(0) for t in embeds_list)
-        padded_embeds = []
-        padded_masks = []
-        for embeds, mask in zip(embeds_list, mask_list):
-            pad_len = max_len - embeds.size(0)
-            if pad_len > 0:
-                embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
-                mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
-            padded_embeds.append(embeds)
-            padded_masks.append(mask)
-
-        inputs_embeds = torch.stack(padded_embeds)
-        attention_mask = torch.stack(padded_masks)
-
-        outputs = model.generate(
-            inputs_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            max_new_tokens=8,
-            temperature=0.0,
+        texts = audio_model.generate(
+            prompts,
+            audio_tensor,
+            {"max_new_tokens": 8, "temperature": 0.0, "do_sample": False},
         )
-        texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         answers = batch["answer"]
         subjects = batch["subject"]
         for text, ans, subject in zip(texts, answers, subjects):
-            match = re.search(r"\b([ABCD])\b", text.strip().upper())
+            match = re.search(r"([ABCD])", text.strip().upper())
             pred = match.group(1) if match else ""
             total += 1
             stats = per_subject.setdefault(subject, {"correct": 0, "total": 0})
@@ -771,7 +788,7 @@ def evaluate_mmlu_speech(
             if pred == ans:
                 correct += 1
                 stats["correct"] += 1
-            if len(qualitative) < 10 and is_main_process():
+            if len(qualitative) < 10:
                 qualitative.append({"subject": subject, "prediction": pred, "gold": ans, "raw": text})
 
     overall = correct / max(total, 1)
@@ -789,21 +806,23 @@ def evaluate_mmlu_speech(
     return overall, subject_scores, qualitative
 
 
+
 # ---------------------------------------------------------------------------
 # Checkpointing & Resume
 # ---------------------------------------------------------------------------
 
 
-def save_checkpoint(cfg: TrainingConfig, model, audio_projector, global_step: int, loss: float, best_loss: float):
+def save_checkpoint(cfg: TrainingConfig, audio_model: AudioLLMModel, global_step: int, loss: float, best_loss: float):
     if not is_main_process():
         return
     os.makedirs(cfg.output_dir, exist_ok=True)
     adapter_dir = Path(cfg.output_dir) / "adapters"
     projector_path = Path(cfg.output_dir) / "audio_projector.pt"
     adapter_dir.mkdir(parents=True, exist_ok=True)
-    model_to_save = model.module if isinstance(model, DDP) else model
+    model_to_save = audio_model.unwrap(audio_model.llm)
     model_to_save.save_pretrained(str(adapter_dir))
-    torch.save(audio_projector.state_dict(), projector_path)
+    projector_to_save = audio_model.unwrap(audio_model.audio_projector)
+    torch.save(projector_to_save.state_dict(), projector_path)
     if cfg.save_state:
         state_path = Path(cfg.output_dir) / "training_state.json"
         with open(state_path, "w", encoding="utf-8") as f:
@@ -812,18 +831,20 @@ def save_checkpoint(cfg: TrainingConfig, model, audio_projector, global_step: in
         print(f"Saved checkpoint to {cfg.output_dir}")
 
 
-def load_resume(cfg: TrainingConfig, model, audio_projector):
+def load_resume(cfg: TrainingConfig, audio_model: AudioLLMModel):
     if cfg.resume is None:
         return
     adapter_dir = Path(cfg.resume)
     projector_path = adapter_dir / "audio_projector.pt"
     adapter_subdir = adapter_dir / "adapters"
     if adapter_subdir.exists():
-        model.load_adapter(str(adapter_subdir), adapter_name="default", is_trainable=True)
-        model.set_adapter("default")
+        base_model = audio_model.unwrap(audio_model.llm)
+        base_model.load_adapter(str(adapter_subdir), adapter_name="default", is_trainable=True)
+        base_model.set_adapter("default")
     if projector_path.exists():
         state = torch.load(projector_path, map_location="cpu")
-        audio_projector.load_state_dict(state)
+        target_projector = audio_model.unwrap(audio_model.audio_projector)
+        target_projector.load_state_dict(state)
     if is_main_process():
         print(f"Resumed from {cfg.resume}")
 
@@ -833,8 +854,7 @@ def load_resume(cfg: TrainingConfig, model, audio_projector):
 # ---------------------------------------------------------------------------
 
 
-def infer_from_audio(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper_encoder, feature_extractor, path: str):
-    device = next(model.parameters()).device
+def infer_from_audio(cfg: TrainingConfig, audio_model: AudioLLMModel, feature_extractor, path: str):
     waveform, sr = sf.read(path)
     if sr != cfg.sample_rate:
         waveform = torchaudio.functional.resample(torch.tensor(waveform).float(), sr, cfg.sample_rate).numpy()
@@ -842,8 +862,8 @@ def infer_from_audio(cfg: TrainingConfig, model, tokenizer, audio_projector, whi
         waveform,
         sampling_rate=cfg.sample_rate,
         return_tensors="pt",
-    )["input_features"].to(device)
-    texts = generate_from_audio_batch(cfg, model, tokenizer, audio_projector, whisper_encoder, features)
+    )["input_features"].to(torch.float32)
+    texts = generate_from_audio_batch(cfg, audio_model, features)
     if is_main_process():
         print("Inference output:", texts[0])
     return texts[0]
@@ -865,22 +885,39 @@ def main():
 
     model, tokenizer = load_llm_and_tokenizer(cfg)
     whisper_encoder, feature_extractor = load_frozen_whisper_encoder(cfg)
-    audio_projector = AudioProjector(
+    audio_projector = AudioSubsamplingProjector(
         input_dim=whisper_encoder.config.d_model,
         output_dim=model.config.hidden_size,
-        n_tokens=cfg.n_audio_tokens,
+        subsample_factor=cfg.audio_subsample,
         hidden_dim=cfg.projector_dim,
+    )
+    audio_model = AudioLLMModel(
+        llm=model,
+        whisper_encoder=whisper_encoder,
+        audio_projector=audio_projector,
+        tokenizer=tokenizer,
+        audio_token=SPECIAL_AUDIO_TOKEN,
     )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = model.to(device)
-    audio_projector = audio_projector.to(device)
-    whisper_encoder = whisper_encoder.to(device)
+    audio_model.llm = audio_model.llm.to(device)
+    audio_model.audio_projector = audio_model.audio_projector.to(device)
+    audio_model.whisper_encoder = audio_model.whisper_encoder.to(device)
+    audio_model.whisper_encoder.eval()
 
-    load_resume(cfg, model, audio_projector)
+    if cfg.ddp and dist.is_initialized():
+        local_rank = int(os.environ.get("LOCAL_RANK", dist.get_rank()))
+        audio_model.llm = DDP(audio_model.llm, device_ids=[local_rank], find_unused_parameters=cfg.ddp_find_unused)
+        audio_model.audio_projector = DDP(
+            audio_model.audio_projector,
+            device_ids=[local_rank],
+            find_unused_parameters=cfg.ddp_find_unused,
+        )
+
+    load_resume(cfg, audio_model)
 
     if cfg.infer_audio:
-        infer_from_audio(cfg, model, tokenizer, audio_projector, whisper_encoder, feature_extractor, cfg.infer_audio)
+        infer_from_audio(cfg, audio_model, feature_extractor, cfg.infer_audio)
         if cfg.ddp and dist.is_initialized():
             dist.barrier()
         return
@@ -890,15 +927,12 @@ def main():
         train_dataset = train_dataset.select(range(min(len(train_dataset), cfg.train_max_samples)))
 
     if cfg.epochs > 0:
-        run_training(cfg, model, tokenizer, audio_projector, whisper_encoder, train_dataset)
+        run_training(cfg, audio_model, tokenizer, train_dataset)
 
     if cfg.eval_mmlu:
         overall, subject_scores, qualitative = evaluate_mmlu_speech(
             cfg,
-            model,
-            tokenizer,
-            audio_projector,
-            whisper_encoder,
+            audio_model,
             feature_extractor,
             max_samples=cfg.mmlu_max,
         )

--- a/train.py
+++ b/train.py
@@ -1,0 +1,922 @@
+-----BEGIN TRAINING SCRIPT: train.py-----
+#!/usr/bin/env python3
+"""
+Minimal requirements:
+    transformers>=4.44.0
+    datasets>=2.20.0
+    accelerate>=0.33.0
+    peft>=0.11.1
+    torchaudio>=2.3.0
+    soundfile>=0.12.1
+    jiwer>=3.0.3
+    einops
+    bitsandbytes (optional for --use-4bit)
+
+Example usages:
+    python train.py --dataset spokenwoz --train-max-samples 2000 --val-max-samples 200 \
+        --epochs 1 --batch-size 4 --grad-accum 4 --output-dir ./runs/audiollm_small
+
+    torchrun --nproc_per_node=2 train.py --dataset spokenwoz --epochs 1 --ddp \
+        --train-max-samples 4000 --val-max-samples 400 --output-dir ./runs/ddp_test
+
+    python train.py --eval-mmlu --mmlu-max 1500 --resume ./runs/audiollm_small --dataset spokenwoz
+"""
+
+import argparse
+import json
+import math
+import os
+import random
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+import torchaudio
+import soundfile as sf
+
+from datasets import load_dataset
+from jiwer import wer
+from peft import LoraConfig, TaskType, get_peft_model
+from transformers import (
+    AdamW,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    GenerationConfig,
+    get_linear_schedule_with_warmup,
+)
+from transformers import WhisperFeatureExtractor, WhisperModel
+
+SPECIAL_AUDIO_TOKEN = "<|AUDIO|>"
+
+
+@dataclass
+class TrainingConfig:
+    dataset: str = "spokenwoz"
+    train_max_samples: int = 2000
+    val_max_samples: int = 200
+    mmlu_max: int = 1500
+    epochs: int = 1
+    lr: float = 1e-4
+    weight_decay: float = 0.01
+    batch_size: int = 4
+    grad_accum: int = 4
+    use_4bit: bool = False
+    amp: bool = True
+    seed: int = 42
+    output_dir: str = "./runs/audiollama"
+    cache_dir: Optional[str] = None
+    eval_mmlu: bool = False
+    eval_every: int = 200
+    save_every: int = 200
+    resume: Optional[str] = None
+    projector_dim: int = 1024
+    n_audio_tokens: int = 12
+    sample_rate: int = 16000
+    max_duration_s: float = 12.0
+    warmup_ratio: float = 0.03
+    logging_steps: int = 10
+    clip_grad_norm: Optional[float] = 1.0
+    ddp: bool = False
+    num_workers: int = 2
+    pin_memory: bool = True
+    eval_split: str = "validation"
+    amp_bf16: bool = True
+    system_prompt: str = "You are an assistant for spoken multiple-choice exams."
+    user_template: str = "<AUDIO> Select the correct option."
+    assistant_prefix: str = "Answer:"
+    infer_audio: Optional[str] = None
+    save_state: bool = True
+    ddp_find_unused: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> TrainingConfig:
+    parser = argparse.ArgumentParser(description="AudioChatLLaMA-like training script")
+    parser.add_argument("--dataset", choices=["spokenwoz", "slurp", "dailytalk", "commonvoice"], default="spokenwoz")
+    parser.add_argument("--train-max-samples", type=int, default=2000)
+    parser.add_argument("--val-max-samples", type=int, default=200)
+    parser.add_argument("--mmlu-max", type=int, default=1500)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--grad-accum", type=int, default=4)
+    parser.add_argument("--use-4bit", action="store_true")
+    parser.add_argument("--amp", action="store_true", default=True)
+    parser.add_argument("--no-amp", action="store_false", dest="amp")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=str, default="./runs/audiollama")
+    parser.add_argument("--cache-dir", type=str, default=None)
+    parser.add_argument("--eval-mmlu", action="store_true")
+    parser.add_argument("--eval-every", type=int, default=200)
+    parser.add_argument("--save-every", type=int, default=200)
+    parser.add_argument("--resume", type=str, default=None, help="Path to directory with adapters/audio_projector.pt")
+    parser.add_argument("--projector-dim", type=int, default=1024)
+    parser.add_argument("--n-audio-tokens", type=int, default=12)
+    parser.add_argument("--sample-rate", type=int, default=16000)
+    parser.add_argument("--max-duration-s", type=float, default=12.0)
+    parser.add_argument("--warmup-ratio", type=float, default=0.03)
+    parser.add_argument("--logging-steps", type=int, default=10)
+    parser.add_argument("--clip-grad-norm", type=float, default=1.0)
+    parser.add_argument("--ddp", action="store_true")
+    parser.add_argument("--ddp-find-unused", action="store_true")
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--pin-memory", action="store_true")
+    parser.add_argument("--no-pin-memory", action="store_false", dest="pin_memory")
+    parser.add_argument("--infer-audio", type=str, default=None)
+    parser.add_argument("--save-state", action="store_true", default=True)
+    parser.add_argument("--no-save-state", action="store_false", dest="save_state")
+    args = parser.parse_args()
+
+    cfg = TrainingConfig(
+        dataset=args.dataset,
+        train_max_samples=args.train_max_samples,
+        val_max_samples=args.val_max_samples,
+        mmlu_max=args.mmlu_max,
+        epochs=args.epochs,
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        batch_size=args.batch_size,
+        grad_accum=args.grad_accum,
+        use_4bit=args.use_4bit,
+        amp=args.amp,
+        seed=args.seed,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        eval_mmlu=args.eval_mmlu,
+        eval_every=args.eval_every,
+        save_every=args.save_every,
+        resume=args.resume,
+        projector_dim=args.projector_dim,
+        n_audio_tokens=args.n_audio_tokens,
+        sample_rate=args.sample_rate,
+        max_duration_s=args.max_duration_s,
+        warmup_ratio=args.warmup_ratio,
+        logging_steps=args.logging_steps,
+        clip_grad_norm=args.clip_grad_norm,
+        ddp=args.ddp,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+        infer_audio=args.infer_audio,
+        save_state=args.save_state,
+        ddp_find_unused=args.ddp_find_unused,
+    )
+    return cfg
+
+
+def is_main_process() -> bool:
+    if not dist.is_available() or not dist.is_initialized():
+        return True
+    return dist.get_rank() == 0
+
+
+def setup_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+# ---------------------------------------------------------------------------
+# Model loading utilities
+# ---------------------------------------------------------------------------
+
+
+def load_llm_and_tokenizer(cfg: TrainingConfig):
+    tokenizer = AutoTokenizer.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        use_fast=False,
+    )
+    if SPECIAL_AUDIO_TOKEN not in tokenizer.get_vocab():
+        tokenizer.add_special_tokens({"additional_special_tokens": [SPECIAL_AUDIO_TOKEN]})
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    compute_dtype = torch.float16
+    if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+        compute_dtype = torch.bfloat16
+
+    quant_config = None
+    if cfg.use_4bit:
+        quant_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=compute_dtype,
+            bnb_4bit_use_double_quant=True,
+        )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "Qwen/Qwen3-0.6B-Base",
+        cache_dir=cfg.cache_dir,
+        torch_dtype=compute_dtype,
+        quantization_config=quant_config,
+        device_map="auto" if cfg.use_4bit else None,
+    )
+    model.resize_token_embeddings(len(tokenizer))
+
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+        lora_dropout=0.05,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM,
+    )
+    model = get_peft_model(model, lora_config)
+    model.config.use_cache = False
+    model.gradient_checkpointing_enable()
+    model.enable_input_require_grads()
+    return model, tokenizer
+
+
+def load_frozen_whisper_encoder(cfg: TrainingConfig):
+    feature_extractor = WhisperFeatureExtractor.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper = WhisperModel.from_pretrained(
+        "openai/whisper-medium",
+        cache_dir=cfg.cache_dir,
+    )
+    whisper.encoder.requires_grad_(False)
+    whisper.encoder.eval()
+    return whisper.encoder, feature_extractor
+
+
+class AudioProjector(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, n_tokens: int, hidden_dim: int):
+        super().__init__()
+        self.n_tokens = n_tokens
+        hidden_dim = hidden_dim or max(input_dim, output_dim)
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, n_tokens * output_dim),
+        )
+        self.output_dim = output_dim
+
+    def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        pooled = encoder_hidden_states.mean(dim=1)
+        projected = self.net(pooled)
+        projected = projected.view(-1, self.n_tokens, self.output_dim)
+        return projected
+
+
+# ---------------------------------------------------------------------------
+# Dataset helpers
+# ---------------------------------------------------------------------------
+
+
+def _resample_audio(audio: Dict[str, Any], target_sr: int) -> np.ndarray:
+    array = audio["array"] if isinstance(audio, dict) else audio
+    sr = audio.get("sampling_rate", target_sr) if isinstance(audio, dict) else target_sr
+    if sr != target_sr:
+        tensor = torch.tensor(array).float()
+        array = torchaudio.functional.resample(tensor, sr, target_sr).numpy()
+    return np.asarray(array, dtype=np.float32)
+
+
+def _compute_features(batch: Dict[str, Any], feature_extractor, cfg: TrainingConfig) -> Dict[str, Any]:
+    waveform = _resample_audio(batch["audio"], cfg.sample_rate)
+    duration = waveform.shape[-1] / cfg.sample_rate
+    if duration > cfg.max_duration_s:
+        waveform = waveform[: int(cfg.max_duration_s * cfg.sample_rate)]
+    batch["input_features"] = feature_extractor(
+        waveform,
+        sampling_rate=cfg.sample_rate,
+        return_tensors="pt",
+    )["input_features"][0]
+    return batch
+
+
+def _fallback_dataset(cfg: TrainingConfig, feature_extractor, num_samples: int = 200):
+    rng = np.random.default_rng(cfg.seed)
+    examples = []
+    for _ in range(num_samples):
+        waveform = rng.normal(0, 0.01, size=int(cfg.sample_rate * 2.5)).astype(np.float32)
+        features = feature_extractor(
+            waveform,
+            sampling_rate=cfg.sample_rate,
+            return_tensors="pt",
+        )["input_features"][0]
+        examples.append({
+            "input_features": features,
+            "text": "Synthetic answer placeholder.",
+            "audio": {"array": waveform, "sampling_rate": cfg.sample_rate},
+        })
+    from datasets import Dataset
+
+    return Dataset.from_list(examples)
+
+
+def load_dataset_by_name(cfg: TrainingConfig, feature_extractor) -> Dataset:
+    target = cfg.dataset.lower()
+    name_map = {
+        "spokenwoz": "facebook/SpokenWOZ",
+        "slurp": "slurp",
+        "dailytalk": "daily_dialog",
+        "commonvoice": "mozilla-foundation/common_voice_11_0",
+    }
+    dataset_name = name_map.get(target, "facebook/SpokenWOZ")
+    split = "train"
+    if target == "commonvoice":
+        split = "train[:2000]"
+    try:
+        dataset = load_dataset(dataset_name, split=split, cache_dir=cfg.cache_dir)
+    except Exception as exc:
+        if is_main_process():
+            print(f"Dataset {dataset_name} unavailable due to {exc}; using synthetic fallback")
+        return _fallback_dataset(cfg, feature_extractor)
+
+    def mapper(example):
+        audio = None
+        for key in ["audio", "speech", "target_speech", "spoken_audio", "sound"]:
+            if key in example and example[key] is not None:
+                audio = example[key]
+                break
+        if audio is None:
+            return None
+        text = example.get("text") or example.get("response") or example.get("sentence") or example.get("answer")
+        if isinstance(text, list):
+            text = " ".join(str(t) for t in text if t)
+        if text is None:
+            text = ""
+        return {"audio": audio, "text": text}
+
+    dataset = dataset.map(mapper, remove_columns=dataset.column_names)
+    dataset = dataset.filter(lambda x: x is not None and x["text"])
+    dataset = dataset.map(lambda x: _compute_features(x, feature_extractor, cfg))
+    return dataset
+
+
+class SFTCollator:
+    def __init__(self, tokenizer, cfg: TrainingConfig):
+        self.tokenizer = tokenizer
+        self.cfg = cfg
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        audio_features = [torch.tensor(f["input_features"], dtype=torch.float32) for f in features]
+        texts = [f["text"] for f in features]
+        prompt_pairs = []
+        for text in texts:
+            system = self.cfg.system_prompt
+            user = self.cfg.user_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+            assistant = f"{self.cfg.assistant_prefix} {text}".strip()
+            prompt_pairs.append((f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:", assistant))
+
+        input_ids = []
+        loss_masks = []
+        for prompt, answer in prompt_pairs:
+            prompt_ids = self.tokenizer(prompt, add_special_tokens=False).input_ids
+            answer_ids = self.tokenizer(answer + self.tokenizer.eos_token, add_special_tokens=False).input_ids
+            ids = prompt_ids + answer_ids
+            mask = [0] * len(prompt_ids) + [1] * len(answer_ids)
+            input_ids.append(torch.tensor(ids, dtype=torch.long))
+            loss_masks.append(torch.tensor(mask, dtype=torch.long))
+
+        max_len = max(t.size(0) for t in input_ids)
+        padded_ids, padded_masks = [], []
+        for ids, mask in zip(input_ids, loss_masks):
+            pad_len = max_len - ids.size(0)
+            if pad_len > 0:
+                ids = torch.cat([ids, torch.full((pad_len,), self.tokenizer.pad_token_id, dtype=torch.long)])
+                mask = torch.cat([mask, torch.zeros(pad_len, dtype=torch.long)])
+            padded_ids.append(ids)
+            padded_masks.append(mask)
+
+        batch = {
+            "input_features": torch.stack(audio_features),
+            "input_ids": torch.stack(padded_ids),
+            "loss_mask": torch.stack(padded_masks),
+        }
+        return batch
+
+
+# ---------------------------------------------------------------------------
+# Input preparation
+# ---------------------------------------------------------------------------
+
+
+def make_inputs_embeds_and_labels(
+    cfg: TrainingConfig,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    batch: Dict[str, torch.Tensor],
+    device: torch.device,
+):
+    input_features = batch["input_features"].to(device)
+    input_ids = batch["input_ids"].to(device)
+    loss_mask = batch["loss_mask"].to(device)
+
+    with torch.no_grad():
+        whisper_outputs = whisper_encoder(input_features)
+        audio_hidden = whisper_outputs.last_hidden_state
+    audio_tokens = audio_projector(audio_hidden)
+
+    token_embeds = model.get_input_embeddings()(input_ids)
+    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+    expanded_embeds = []
+    expanded_labels = []
+    expanded_masks = []
+    for b in range(input_ids.size(0)):
+        ids = input_ids[b]
+        embeds = token_embeds[b]
+        labels = ids.clone()
+        labels[loss_mask[b] == 0] = -100
+        seq_embeds: List[torch.Tensor] = []
+        seq_labels: List[torch.Tensor] = []
+        seq_mask: List[torch.Tensor] = []
+        inserted = 0
+        for idx, (token_id, token_embed, label_val) in enumerate(zip(ids, embeds, labels)):
+            if token_id == audio_token_id:
+                for j in range(audio_projector.n_audio_tokens):
+                    seq_embeds.append(audio_tokens[b, j])
+                    seq_labels.append(torch.tensor(-100, device=device))
+                    seq_mask.append(torch.tensor(1, device=device))
+                inserted += 1
+            else:
+                seq_embeds.append(token_embed)
+                seq_labels.append(label_val)
+                seq_mask.append(torch.tensor(1, device=device))
+        seq_embeds = torch.stack(seq_embeds)
+        seq_labels = torch.stack(seq_labels)
+        seq_mask = torch.stack(seq_mask)
+        expanded_embeds.append(seq_embeds)
+        expanded_labels.append(seq_labels)
+        expanded_masks.append(seq_mask)
+
+    max_len = max(t.size(0) for t in expanded_embeds)
+    padded_embeds, padded_labels, padded_masks = [], [], []
+    for embeds, labels, mask in zip(expanded_embeds, expanded_labels, expanded_masks):
+        pad_len = max_len - embeds.size(0)
+        if pad_len > 0:
+            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+            labels = torch.cat([labels, torch.full((pad_len,), -100, device=device, dtype=torch.long)])
+            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+        padded_embeds.append(embeds)
+        padded_labels.append(labels)
+        padded_masks.append(mask)
+
+    inputs_embeds = torch.stack(padded_embeds)
+    attention_mask = torch.stack(padded_masks)
+    labels = torch.stack(padded_labels)
+    return inputs_embeds, attention_mask, labels
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+
+def train_epoch(
+    cfg: TrainingConfig,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    dataloader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    scheduler,
+    device: torch.device,
+    epoch: int,
+    scaler: Optional[torch.cuda.amp.GradScaler] = None,
+):
+    model.train()
+    audio_projector.train()
+    total_loss = 0.0
+    step = 0
+
+    for batch_idx, batch in enumerate(dataloader):
+        inputs_embeds, attention_mask, labels = make_inputs_embeds_and_labels(
+            cfg,
+            model,
+            tokenizer,
+            audio_projector,
+            whisper_encoder,
+            batch,
+            device,
+        )
+
+        with torch.cuda.amp.autocast(enabled=cfg.amp and device.type == "cuda"):
+            outputs = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask, labels=labels)
+            loss = outputs.loss / cfg.grad_accum
+
+        if scaler is not None:
+            scaler.scale(loss).backward()
+        else:
+            loss.backward()
+
+        if (batch_idx + 1) % cfg.grad_accum == 0:
+            if scaler is not None:
+                scaler.unscale_(optimizer)
+            if cfg.clip_grad_norm is not None:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad_norm)
+                torch.nn.utils.clip_grad_norm_(audio_projector.parameters(), cfg.clip_grad_norm)
+            if scaler is not None:
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                optimizer.step()
+            scheduler.step()
+            optimizer.zero_grad()
+
+        total_loss += loss.item() * cfg.grad_accum
+        step += 1
+        if step % cfg.logging_steps == 0 and is_main_process():
+            print(f"Epoch {epoch} Step {step} Loss {total_loss / step:.4f}")
+
+    return total_loss / max(step, 1)
+
+
+def run_training(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper_encoder, train_dataset):
+    sampler = None
+    if cfg.ddp and dist.is_initialized():
+        sampler = DistributedSampler(train_dataset, shuffle=True)
+    dataloader = DataLoader(
+        train_dataset,
+        batch_size=cfg.batch_size,
+        sampler=sampler,
+        shuffle=sampler is None,
+        collate_fn=SFTCollator(tokenizer, cfg),
+        num_workers=cfg.num_workers,
+        pin_memory=cfg.pin_memory,
+    )
+
+    optimizer = AdamW(
+        list(model.parameters()) + list(audio_projector.parameters()),
+        lr=cfg.lr,
+        weight_decay=cfg.weight_decay,
+    )
+    num_training_steps = math.ceil(len(dataloader) / cfg.grad_accum) * cfg.epochs
+    scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=int(cfg.warmup_ratio * num_training_steps),
+        num_training_steps=num_training_steps,
+    )
+
+    scaler = torch.cuda.amp.GradScaler(enabled=cfg.amp and torch.cuda.is_available())
+    device = next(model.parameters()).device
+
+    global_step = 0
+    best_loss = float("inf")
+    for epoch in range(cfg.epochs):
+        if sampler is not None:
+            sampler.set_epoch(epoch)
+        avg_loss = train_epoch(
+            cfg,
+            model,
+            tokenizer,
+            audio_projector,
+            whisper_encoder,
+            dataloader,
+            optimizer,
+            scheduler,
+            device,
+            epoch,
+            scaler,
+        )
+        if is_main_process():
+            print(f"Epoch {epoch} avg loss {avg_loss:.4f}")
+        best_loss = min(best_loss, avg_loss)
+        global_step += len(dataloader)
+        if is_main_process():
+            save_checkpoint(cfg, model, audio_projector, global_step, avg_loss, best_loss)
+    return best_loss
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def generate_from_audio_batch(
+    cfg: TrainingConfig,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    audio_features: torch.Tensor,
+    max_new_tokens: int = 64,
+    temperature: float = 0.0,
+):
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        whisper_outputs = whisper_encoder(audio_features.to(device))
+        audio_hidden = whisper_outputs.last_hidden_state
+    audio_tokens = audio_projector(audio_hidden)
+
+    prompts = []
+    for _ in range(audio_features.size(0)):
+        system = cfg.system_prompt
+        user = cfg.user_template.replace("<AUDIO>", SPECIAL_AUDIO_TOKEN)
+        prompts.append(f"SYSTEM: {system}\nUSER: {user}\nASSISTANT:")
+
+    encoded = tokenizer(prompts, return_tensors="pt", padding=True, add_special_tokens=False).to(device)
+    token_embeds = model.get_input_embeddings()(encoded.input_ids)
+    audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+    embeds_list = []
+    mask_list = []
+    for b in range(encoded.input_ids.size(0)):
+        ids = encoded.input_ids[b]
+        embeds = token_embeds[b]
+        seq = []
+        for token_id, token_embed in zip(ids, embeds):
+            if token_id == audio_token_id:
+                seq.append(audio_tokens[b])
+            else:
+                seq.append(token_embed.unsqueeze(0))
+        seq = torch.cat(seq, dim=0)
+        embeds_list.append(seq)
+        mask_list.append(torch.ones(seq.size(0), device=device))
+
+    max_len = max(t.size(0) for t in embeds_list)
+    padded_embeds = []
+    padded_masks = []
+    for embeds, mask in zip(embeds_list, mask_list):
+        pad_len = max_len - embeds.size(0)
+        if pad_len > 0:
+            embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+            mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+        padded_embeds.append(embeds)
+        padded_masks.append(mask)
+
+    inputs_embeds = torch.stack(padded_embeds)
+    attention_mask = torch.stack(padded_masks)
+
+    outputs = model.generate(
+        inputs_embeds=inputs_embeds,
+        attention_mask=attention_mask,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        do_sample=temperature > 0,
+        pad_token_id=tokenizer.pad_token_id,
+        eos_token_id=tokenizer.eos_token_id,
+    )
+    texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+    return texts
+
+
+def evaluate_mmlu_speech(
+    cfg: TrainingConfig,
+    model: AutoModelForCausalLM,
+    tokenizer,
+    audio_projector: AudioProjector,
+    whisper_encoder,
+    feature_extractor,
+    max_samples: Optional[int] = None,
+):
+    dataset = load_dataset("mistralai/mmlu_speech", split="validation", cache_dir=cfg.cache_dir)
+    if max_samples:
+        dataset = dataset.select(range(min(len(dataset), max_samples)))
+
+    dataloader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=False)
+    device = next(model.parameters()).device
+
+    total = 0
+    correct = 0
+    per_subject: Dict[str, Dict[str, int]] = {}
+    qualitative: List[Dict[str, Any]] = []
+
+    for batch in dataloader:
+        audio_list = []
+        for audio in batch["audio"]:
+            waveform = _resample_audio(audio, cfg.sample_rate)
+            feats = feature_extractor(
+                waveform,
+                sampling_rate=cfg.sample_rate,
+                return_tensors="pt",
+            )["input_features"][0]
+            audio_list.append(feats)
+        audio_tensor = torch.stack(audio_list).to(device)
+        with torch.no_grad():
+            whisper_outputs = whisper_encoder(audio_tensor)
+            audio_hidden = whisper_outputs.last_hidden_state
+        audio_tokens = audio_projector(audio_hidden)
+
+        prompts = []
+        prefix = "Listen to the audio question and select the correct answer (A/B/C/D). Return just the letter."
+        for _ in range(audio_tensor.size(0)):
+            prompts.append(
+                f"SYSTEM: {cfg.system_prompt}\nUSER: {SPECIAL_AUDIO_TOKEN} {prefix} Select the correct option: A, B, C, or D. Reply with one letter.\nASSISTANT:"
+            )
+
+        encoded = tokenizer(prompts, return_tensors="pt", padding=True, add_special_tokens=False).to(device)
+        token_embeds = model.get_input_embeddings()(encoded.input_ids)
+        audio_token_id = tokenizer.convert_tokens_to_ids(SPECIAL_AUDIO_TOKEN)
+
+        embeds_list = []
+        mask_list = []
+        for b in range(encoded.input_ids.size(0)):
+            ids = encoded.input_ids[b]
+            embeds = token_embeds[b]
+            seq = []
+            for token_id, token_embed in zip(ids, embeds):
+                if token_id == audio_token_id:
+                    seq.append(audio_tokens[b])
+                else:
+                    seq.append(token_embed.unsqueeze(0))
+            seq = torch.cat(seq, dim=0)
+            embeds_list.append(seq)
+            mask_list.append(torch.ones(seq.size(0), device=device))
+
+        max_len = max(t.size(0) for t in embeds_list)
+        padded_embeds = []
+        padded_masks = []
+        for embeds, mask in zip(embeds_list, mask_list):
+            pad_len = max_len - embeds.size(0)
+            if pad_len > 0:
+                embeds = torch.cat([embeds, torch.zeros((pad_len, embeds.size(1)), device=device)], dim=0)
+                mask = torch.cat([mask, torch.zeros(pad_len, device=device)], dim=0)
+            padded_embeds.append(embeds)
+            padded_masks.append(mask)
+
+        inputs_embeds = torch.stack(padded_embeds)
+        attention_mask = torch.stack(padded_masks)
+
+        outputs = model.generate(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            max_new_tokens=8,
+            temperature=0.0,
+        )
+        texts = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        answers = batch["answer"]
+        subjects = batch["subject"]
+        for text, ans, subject in zip(texts, answers, subjects):
+            match = re.search(r"\b([ABCD])\b", text.strip().upper())
+            pred = match.group(1) if match else ""
+            total += 1
+            stats = per_subject.setdefault(subject, {"correct": 0, "total": 0})
+            stats["total"] += 1
+            if pred == ans:
+                correct += 1
+                stats["correct"] += 1
+            if len(qualitative) < 10 and is_main_process():
+                qualitative.append({"subject": subject, "prediction": pred, "gold": ans, "raw": text})
+
+    overall = correct / max(total, 1)
+    subject_scores = {
+        subj: stats["correct"] / max(stats["total"], 1)
+        for subj, stats in sorted(per_subject.items(), key=lambda item: item[0])
+    }
+    if is_main_process():
+        print(f"MMLU-Speech overall accuracy: {overall:.4f}")
+        for subject, score in list(subject_scores.items())[:10]:
+            print(f"  {subject}: {score:.3f}")
+        print("Qualitative samples:")
+        for example in qualitative:
+            print(example)
+    return overall, subject_scores, qualitative
+
+
+# ---------------------------------------------------------------------------
+# Checkpointing & Resume
+# ---------------------------------------------------------------------------
+
+
+def save_checkpoint(cfg: TrainingConfig, model, audio_projector, global_step: int, loss: float, best_loss: float):
+    if not is_main_process():
+        return
+    os.makedirs(cfg.output_dir, exist_ok=True)
+    adapter_dir = Path(cfg.output_dir) / "adapters"
+    projector_path = Path(cfg.output_dir) / "audio_projector.pt"
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+    model_to_save = model.module if isinstance(model, DDP) else model
+    model_to_save.save_pretrained(str(adapter_dir))
+    torch.save(audio_projector.state_dict(), projector_path)
+    if cfg.save_state:
+        state_path = Path(cfg.output_dir) / "training_state.json"
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump({"global_step": global_step, "loss": loss, "best_loss": best_loss}, f, indent=2)
+    if is_main_process():
+        print(f"Saved checkpoint to {cfg.output_dir}")
+
+
+def load_resume(cfg: TrainingConfig, model, audio_projector):
+    if cfg.resume is None:
+        return
+    adapter_dir = Path(cfg.resume)
+    projector_path = adapter_dir / "audio_projector.pt"
+    adapter_subdir = adapter_dir / "adapters"
+    if adapter_subdir.exists():
+        model.load_adapter(str(adapter_subdir), adapter_name="default", is_trainable=True)
+        model.set_adapter("default")
+    if projector_path.exists():
+        state = torch.load(projector_path, map_location="cpu")
+        audio_projector.load_state_dict(state)
+    if is_main_process():
+        print(f"Resumed from {cfg.resume}")
+
+
+# ---------------------------------------------------------------------------
+# Inference helper
+# ---------------------------------------------------------------------------
+
+
+def infer_from_audio(cfg: TrainingConfig, model, tokenizer, audio_projector, whisper_encoder, feature_extractor, path: str):
+    device = next(model.parameters()).device
+    waveform, sr = sf.read(path)
+    if sr != cfg.sample_rate:
+        waveform = torchaudio.functional.resample(torch.tensor(waveform).float(), sr, cfg.sample_rate).numpy()
+    features = feature_extractor(
+        waveform,
+        sampling_rate=cfg.sample_rate,
+        return_tensors="pt",
+    )["input_features"].to(device)
+    texts = generate_from_audio_batch(cfg, model, tokenizer, audio_projector, whisper_encoder, features)
+    if is_main_process():
+        print("Inference output:", texts[0])
+    return texts[0]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    cfg = parse_args()
+    if cfg.ddp:
+        dist.init_process_group(backend="nccl")
+    setup_seed(cfg.seed + (dist.get_rank() if dist.is_initialized() else 0))
+    if is_main_process():
+        print("Config:")
+        print(json.dumps(asdict(cfg), indent=2))
+
+    model, tokenizer = load_llm_and_tokenizer(cfg)
+    whisper_encoder, feature_extractor = load_frozen_whisper_encoder(cfg)
+    audio_projector = AudioProjector(
+        input_dim=whisper_encoder.config.d_model,
+        output_dim=model.config.hidden_size,
+        n_tokens=cfg.n_audio_tokens,
+        hidden_dim=cfg.projector_dim,
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    audio_projector = audio_projector.to(device)
+    whisper_encoder = whisper_encoder.to(device)
+
+    load_resume(cfg, model, audio_projector)
+
+    if cfg.infer_audio:
+        infer_from_audio(cfg, model, tokenizer, audio_projector, whisper_encoder, feature_extractor, cfg.infer_audio)
+        if cfg.ddp and dist.is_initialized():
+            dist.barrier()
+        return
+
+    train_dataset = load_dataset_by_name(cfg, feature_extractor)
+    if cfg.train_max_samples:
+        train_dataset = train_dataset.select(range(min(len(train_dataset), cfg.train_max_samples)))
+
+    if cfg.epochs > 0:
+        run_training(cfg, model, tokenizer, audio_projector, whisper_encoder, train_dataset)
+
+    if cfg.eval_mmlu:
+        overall, subject_scores, qualitative = evaluate_mmlu_speech(
+            cfg,
+            model,
+            tokenizer,
+            audio_projector,
+            whisper_encoder,
+            feature_extractor,
+            max_samples=cfg.mmlu_max,
+        )
+        if is_main_process():
+            metrics_path = Path(cfg.output_dir) / "metrics_mmlu.json"
+            with open(metrics_path, "w", encoding="utf-8") as f:
+                json.dump({
+                    "overall_accuracy": overall,
+                    "per_subject": subject_scores,
+                    "examples": qualitative,
+                }, f, indent=2)
+            print(f"Saved MMLU metrics to {metrics_path}")
+
+    if cfg.ddp and dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+-----END TRAINING SCRIPT: train.py-----


### PR DESCRIPTION
## Summary
- add a fully-populated teacher Colab notebook implementing the AudioChatLLaMA-style SFT and evaluation pipeline
- add a student Colab notebook with guided TODOs for core training, projection, and evaluation steps
- provide a configurable train.py script for local/CLI training, evaluation, checkpointing, and inference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d627507b44832992c2538a87738c43